### PR TITLE
app/internal/window,cmd/gogio: fix golint issues and sort imports using goimports

### DIFF
--- a/app/internal/window/os_wayland.go
+++ b/app/internal/window/os_wayland.go
@@ -1445,7 +1445,7 @@ func (w *window) setStage(s system.Stage) {
 		return
 	}
 	w.stage = s
-	w.w.Event(system.StageEvent{s})
+	w.w.Event(system.StageEvent{Stage: s})
 }
 
 func (w *window) display() *C.struct_wl_display {

--- a/app/internal/window/os_x11.go
+++ b/app/internal/window/os_x11.go
@@ -180,7 +180,7 @@ func (w *x11Window) setStage(s system.Stage) {
 		return
 	}
 	w.stage = s
-	w.w.Event(system.StageEvent{s})
+	w.w.Event(system.StageEvent{Stage: s})
 }
 
 func (w *x11Window) loop() {

--- a/cmd/gogio/jsbuild.go
+++ b/cmd/gogio/jsbuild.go
@@ -4,13 +4,14 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/tools/go/packages"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 )
 
 func buildJS(bi *buildInfo) error {


### PR DESCRIPTION
Golint issues:

	app/internal/window/os_wayland.go:1448:12: gioui.org/io/system.StageEvent composite literal uses unkeyed fields
	app/internal/window/os_x11.go:183:12: gioui.org/io/system.StageEvent composite literal uses unkeyed fields

Goimports command:

	find gio/ -type f -name '*.go' | xargs -I '{}' goimports -w '{}'

---

**Note:** This PR is intended to assess the Gio Sourcehut/GitHub integration. It contains no functional code changes, only stylistic.

Preferably, Gio would be able to employ similar collaboration synchronization tools as those employed by the official Go project, which would enable automatically creating Sourcehut patches for corresponding GitHub PRs made to the Gio mirror repository.

Thusly, consider this PR not as a suggestion for code change to Gio, it may very well be ignored and closed. Consider it instead a test of the integration bridge between the Sourcehut Gio repository and the GitHub Gio mirror repository.

Cheers,
Robin