### PR TITLE
gesture,widget: Text selection in Editor widgets

### DIFF
--- a/gesture/gesture.go
+++ b/gesture/gesture.go
@@ -90,6 +90,7 @@ type Axis uint8
 const (
 	Horizontal Axis = iota
 	Vertical
+	Both
 )
 
 const (
@@ -200,6 +201,8 @@ func (c *Click) Events(q event.Queue) []ClickEvent {
 	}
 	return events
 }
+
+func (ClickEvent) ImplementsEvent() {}
 
 // Add the handler to the operation list to receive scroll events.
 func (s *Scroll) Add(ops *op.Ops) {
@@ -356,6 +359,8 @@ func (d *Drag) Events(cfg unit.Metric, q event.Queue, axis Axis) []pointer.Event
 				e.Position.Y = d.start.Y
 			case Vertical:
 				e.Position.X = d.start.X
+			case Both:
+				// Do nothing
 			}
 			if e.Priority < pointer.Grabbed {
 				diff := e.Position.Sub(d.start)

--- a/widget/buffer.go
+++ b/widget/buffer.go
@@ -3,18 +3,13 @@
 package widget
 
 import (
-	"fmt"
 	"io"
 	"strings"
 	"unicode/utf8"
 )
 
-const bufferDebug = false
-
 // editBuffer implements a gap buffer for text editing.
 type editBuffer struct {
-	// caret is the caret position in bytes.
-	caret int
 	// pos is the byte position for Read and ReadRune.
 	pos int
 
@@ -35,12 +30,12 @@ func (e *editBuffer) Changed() bool {
 	return c
 }
 
-func (e *editBuffer) deleteRunes(runes int) {
-	e.moveGap(0)
+func (e *editBuffer) deleteRunes(caret, runes int) int {
+	e.moveGap(caret, 0)
 	for ; runes < 0 && e.gapstart > 0; runes++ {
 		_, s := utf8.DecodeLastRune(e.text[:e.gapstart])
 		e.gapstart -= s
-		e.caret -= s
+		caret -= s
 		e.changed = e.changed || s > 0
 	}
 	for ; runes > 0 && e.gapend < len(e.text); runes-- {
@@ -48,12 +43,12 @@ func (e *editBuffer) deleteRunes(runes int) {
 		e.gapend += s
 		e.changed = e.changed || s > 0
 	}
-	e.dump()
+	return caret
 }
 
 // moveGap moves the gap to the caret position. After returning,
 // the gap is guaranteed to be at least space bytes long.
-func (e *editBuffer) moveGap(space int) {
+func (e *editBuffer) moveGap(caret, space int) {
 	if e.gapLen() < space {
 		if space < minSpace {
 			space = minSpace
@@ -62,29 +57,28 @@ func (e *editBuffer) moveGap(space int) {
 		// Expand to capacity.
 		txt = txt[:cap(txt)]
 		gaplen := len(txt) - e.len()
-		if e.caret > e.gapstart {
+		if caret > e.gapstart {
 			copy(txt, e.text[:e.gapstart])
-			copy(txt[e.caret+gaplen:], e.text[e.caret:])
-			copy(txt[e.gapstart:], e.text[e.gapend:e.caret+e.gapLen()])
+			copy(txt[caret+gaplen:], e.text[caret:])
+			copy(txt[e.gapstart:], e.text[e.gapend:caret+e.gapLen()])
 		} else {
-			copy(txt, e.text[:e.caret])
+			copy(txt, e.text[:caret])
 			copy(txt[e.gapstart+gaplen:], e.text[e.gapend:])
-			copy(txt[e.caret+gaplen:], e.text[e.caret:e.gapstart])
+			copy(txt[caret+gaplen:], e.text[caret:e.gapstart])
 		}
 		e.text = txt
-		e.gapstart = e.caret
+		e.gapstart = caret
 		e.gapend = e.gapstart + gaplen
 	} else {
-		if e.caret > e.gapstart {
-			copy(e.text[e.gapstart:], e.text[e.gapend:e.caret+e.gapLen()])
+		if caret > e.gapstart {
+			copy(e.text[e.gapstart:], e.text[e.gapend:caret+e.gapLen()])
 		} else {
-			copy(e.text[e.caret+e.gapLen():], e.text[e.caret:e.gapstart])
+			copy(e.text[caret+e.gapLen():], e.text[caret:e.gapstart])
 		}
 		l := e.gapLen()
-		e.gapstart = e.caret
+		e.gapstart = caret
 		e.gapend = e.gapstart + l
 	}
-	e.dump()
 }
 
 func (e *editBuffer) len() int {
@@ -96,7 +90,25 @@ func (e *editBuffer) gapLen() int {
 }
 
 func (e *editBuffer) Reset() {
-	e.pos = 0
+	e.Seek(0, io.SeekStart)
+}
+
+// Seek implements io.Seeker
+func (e *editBuffer) Seek(offset int64, whence int) (ret int64, err error) {
+	switch whence {
+	case io.SeekStart:
+		e.pos = int(offset)
+	case io.SeekCurrent:
+		e.pos += int(offset)
+	case io.SeekEnd:
+		e.pos = e.len() - int(offset)
+	}
+	if e.pos < 0 {
+		e.pos = 0
+	} else if e.pos > e.len() {
+		e.pos = e.len()
+	}
+	return int64(e.pos), nil
 }
 
 func (e *editBuffer) Read(p []byte) (int, error) {
@@ -138,18 +150,11 @@ func (e *editBuffer) String() string {
 	return b.String()
 }
 
-func (e *editBuffer) prepend(s string) {
-	e.moveGap(len(s))
-	copy(e.text[e.caret:], s)
+func (e *editBuffer) prepend(caret int, s string) {
+	e.moveGap(caret, len(s))
+	copy(e.text[caret:], s)
 	e.gapstart += len(s)
 	e.changed = e.changed || len(s) > 0
-	e.dump()
-}
-
-func (e *editBuffer) dump() {
-	if bufferDebug {
-		fmt.Printf("len(e.text) %d e.len() %d e.gapstart %d e.gapend %d e.caret %d txt:\n'%+x'<-%d->'%+x'\n", len(e.text), e.len(), e.gapstart, e.gapend, e.caret, e.text[:e.gapstart], e.gapLen(), e.text[e.gapend:])
-	}
 }
 
 func (e *editBuffer) runeBefore(idx int) (rune, int) {

--- a/widget/editor.go
+++ b/widget/editor.go
@@ -398,12 +398,18 @@ func (e *Editor) command(gtx layout.Context, k key.Event) bool {
 		if moveByWord {
 			e.moveWord(-1, selAct)
 		} else {
+			if selAct == selectionClear {
+				e.ClearSelection()
+			}
 			e.MoveCaret(-1, -1*int(selAct))
 		}
 	case key.NameRightArrow:
 		if moveByWord {
 			e.moveWord(1, selAct)
 		} else {
+			if selAct == selectionClear {
+				e.ClearSelection()
+			}
 			e.MoveCaret(1, int(selAct))
 		}
 	case key.NamePageUp:

--- a/widget/editor_test.go
+++ b/widget/editor_test.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/quick"
 	"unicode"
@@ -15,10 +16,12 @@ import (
 	"gioui.org/font/gofont"
 	"gioui.org/io/event"
 	"gioui.org/io/key"
+	"gioui.org/io/pointer"
 	"gioui.org/layout"
 	"gioui.org/op"
 	"gioui.org/text"
 	"gioui.org/unit"
+	"golang.org/x/image/math/fixed"
 )
 
 func TestEditor(t *testing.T) {
@@ -34,37 +37,37 @@ func TestEditor(t *testing.T) {
 	e.SetText("æbc\naøå•")
 	e.Layout(gtx, cache, font, fontSize)
 	assertCaret(t, e, 0, 0, 0)
-	e.moveEnd()
+	e.moveEnd(selectionClear)
 	assertCaret(t, e, 0, 3, len("æbc"))
-	e.MoveCaret(+1)
+	e.MoveCaret(+1, +1)
 	assertCaret(t, e, 1, 0, len("æbc\n"))
-	e.MoveCaret(-1)
+	e.MoveCaret(-1, -1)
 	assertCaret(t, e, 0, 3, len("æbc"))
-	e.moveLines(+1)
+	e.moveLines(+1, +1)
 	assertCaret(t, e, 1, 3, len("æbc\naøå"))
-	e.moveEnd()
+	e.moveEnd(selectionClear)
 	assertCaret(t, e, 1, 4, len("æbc\naøå•"))
-	e.MoveCaret(+1)
+	e.MoveCaret(+1, +1)
 	assertCaret(t, e, 1, 4, len("æbc\naøå•"))
 
-	e.SetCaret(0)
+	e.SetCaret(0, 0)
 	assertCaret(t, e, 0, 0, 0)
-	e.SetCaret(len("æ"))
+	e.SetCaret(len("æ"), len("æ"))
 	assertCaret(t, e, 0, 1, 2)
-	e.SetCaret(len("æbc\naøå•"))
+	e.SetCaret(len("æbc\naøå•"), len("æbc\naøå•"))
 	assertCaret(t, e, 1, 4, len("æbc\naøå•"))
 
 	// Ensure that password masking does not affect caret behavior
-	e.MoveCaret(-3)
+	e.MoveCaret(-3, -3)
 	assertCaret(t, e, 1, 1, len("æbc\na"))
 	e.Mask = '*'
 	e.Layout(gtx, cache, font, fontSize)
 	assertCaret(t, e, 1, 1, len("æbc\na"))
-	e.MoveCaret(-3)
+	e.MoveCaret(-3, -3)
 	assertCaret(t, e, 0, 2, len("æb"))
 	e.Mask = '\U0001F92B'
 	e.Layout(gtx, cache, font, fontSize)
-	e.moveEnd()
+	e.moveEnd(selectionClear)
 	assertCaret(t, e, 0, 3, len("æbc"))
 
 	// When a password mask is applied, it should replace all visible glyphs
@@ -106,8 +109,8 @@ func assertCaret(t *testing.T, e *Editor, line, col, bytes int) {
 	if gotLine != line || gotCol != col {
 		t.Errorf("caret at (%d, %d), expected (%d, %d)", gotLine, gotCol, line, col)
 	}
-	if bytes != e.caret.pos.ofs {
-		t.Errorf("caret at buffer position %d, expected %d", e.caret.pos.ofs, bytes)
+	if bytes != e.caret.start.ofs {
+		t.Errorf("caret at buffer position %d, expected %d", e.caret.start.ofs, bytes)
 	}
 }
 
@@ -144,7 +147,7 @@ func TestEditorCaretConsistency(t *testing.T) {
 			t.Helper()
 			gotLine, gotCol := e.CaretPos()
 			gotCoords := e.CaretCoords()
-			want, _ := e.offsetToScreenPos(e.caret.pos.ofs)
+			want, _ := e.offsetToScreenPos(e.caret.start.ofs)
 			wantCoords := f32.Pt(float32(want.x)/64, float32(want.y))
 			if want.lineCol.Y == gotLine && want.lineCol.X == gotCol && gotCoords == wantCoords {
 				return nil
@@ -162,19 +165,19 @@ func TestEditorCaretConsistency(t *testing.T) {
 				e.SetText(str)
 				e.Layout(gtx, cache, font, fontSize)
 			case moveRune:
-				e.MoveCaret(int(distance))
+				e.MoveCaret(int(distance), int(distance))
 			case moveLine:
-				e.moveLines(int(distance))
+				e.moveLines(int(distance), selectionClear)
 			case movePage:
-				e.movePages(int(distance))
+				e.movePages(int(distance), selectionClear)
 			case moveStart:
-				e.moveStart()
+				e.moveStart(selectionClear)
 			case moveEnd:
-				e.moveEnd()
+				e.moveEnd(selectionClear)
 			case moveCoord:
 				e.moveCoord(image.Pt(int(x), int(y)))
 			case moveWord:
-				e.moveWord(int(distance))
+				e.moveWord(int(distance), selectionClear)
 			case deleteWord:
 				e.deleteWord(int(distance))
 			default:
@@ -230,38 +233,72 @@ func TestEditorMoveWord(t *testing.T) {
 	}
 	for ii, tt := range tests {
 		e := setup(tt.Text)
-		e.MoveCaret(tt.Start)
-		e.moveWord(tt.Skip)
-		if e.caret.pos.ofs != tt.Want {
-			t.Fatalf("[%d] moveWord: bad caret position: got %d, want %d", ii, e.caret.pos.ofs, tt.Want)
+		e.MoveCaret(tt.Start, tt.Start)
+		e.moveWord(tt.Skip, selectionClear)
+		if e.caret.start.ofs != tt.Want {
+			t.Fatalf("[%d] moveWord: bad caret position: got %d, want %d", ii, e.caret.start.ofs, tt.Want)
 		}
 	}
 }
 
 func TestEditorDeleteWord(t *testing.T) {
 	type Test struct {
-		Text   string
-		Start  int
-		Delete int
+		Text      string
+		Start     int
+		Selection int
+		Delete    int
 
 		Want   int
 		Result string
 	}
 	tests := []Test{
-		{"", 0, 0, 0, ""},
-		{"", 0, -1, 0, ""},
-		{"", 0, 1, 0, ""},
-		{"hello", 0, -1, 0, "hello"},
-		{"hello", 0, 1, 0, ""},
-		{"hello world", 3, 1, 3, "hel world"},
-		{"hello world", 3, -1, 0, "lo world"},
-		{"hello world", 8, -1, 6, "hello rld"},
-		{"hello world", 8, 1, 8, "hello wo"},
-		{"hello    world", 3, 1, 3, "hel    world"},
-		{"hello    world", 3, 2, 3, "helworld"},
-		{"hello    world", 8, 1, 8, "hello   "},
-		{"hello    world", 8, -1, 5, "hello world"},
-		{"hello brave new world", 0, 3, 0, " new world"},
+		// No text selected
+		{"", 0, 0, 0, 0, ""},
+		{"", 0, 0, -1, 0, ""},
+		{"", 0, 0, 1, 0, ""},
+		{"", 0, 0, -2, 0, ""},
+		{"", 0, 0, 2, 0, ""},
+		{"hello", 0, 0, -1, 0, "hello"},
+		{"hello", 0, 0, 1, 0, ""},
+
+		// Document (imho) incorrect behavior w.r.t. deleting spaces following
+		// words.
+		{"hello world", 0, 0, 1, 0, " world"},   // Should be "world", if you ask me.
+		{"hello world", 0, 0, 2, 0, "world"},    // Should be "".
+		{"hello ", 0, 0, 1, 0, " "},             // Should be "".
+		{"hello world", 11, 0, -1, 6, "hello "}, // Should be "hello".
+		{"hello world", 11, 0, -2, 5, "hello"},  // Should be "".
+		{"hello ", 6, 0, -1, 0, ""},             // Correct result.
+
+		{"hello world", 3, 0, 1, 3, "hel world"},
+		{"hello world", 3, 0, -1, 0, "lo world"},
+		{"hello world", 8, 0, -1, 6, "hello rld"},
+		{"hello world", 8, 0, 1, 8, "hello wo"},
+		{"hello    world", 3, 0, 1, 3, "hel    world"},
+		{"hello    world", 3, 0, 2, 3, "helworld"},
+		{"hello    world", 8, 0, 1, 8, "hello   "},
+		{"hello    world", 8, 0, -1, 5, "hello world"},
+		{"hello brave new world", 0, 0, 3, 0, " new world"},
+		// Add selected text.
+		//
+		// Several permutations must be tested:
+		// - select from the left or right
+		// - Delete + or -
+		// - abs(Delete) == 1 or > 1
+		//
+		// "brave |" selected; caret at |
+		{"hello there brave new world", 12, 6, 1, 12, "hello there new world"}, // #16
+		{"hello there brave new world", 12, 6, 2, 12, "hello there  world"},    // The two spaces after "there" are actually suboptimal, if you ask me. See also above cases.
+		{"hello there brave new world", 12, 6, -1, 12, "hello there new world"},
+		{"hello there brave new world", 12, 6, -2, 6, "hello new world"},
+		// "|brave " selected
+		{"hello there brave new world", 18, -6, 1, 12, "hello there new world"}, // #20
+		{"hello there brave new world", 18, -6, 2, 12, "hello there  world"},    // ditto
+		{"hello there brave new world", 18, -6, -1, 12, "hello there new world"},
+		{"hello there brave new world", 18, -6, -2, 6, "hello new world"},
+		// Random edge cases
+		{"hello there brave new world", 12, 6, 99, 12, "hello there "},
+		{"hello there brave new world", 18, -6, -99, 0, "new world"},
 	}
 	setup := func(t string) *Editor {
 		e := new(Editor)
@@ -278,10 +315,11 @@ func TestEditorDeleteWord(t *testing.T) {
 	}
 	for ii, tt := range tests {
 		e := setup(tt.Text)
-		e.MoveCaret(tt.Start)
+		e.MoveCaret(tt.Start, tt.Start)
+		e.MoveCaret(0, tt.Selection)
 		e.deleteWord(tt.Delete)
-		if e.caret.pos.ofs != tt.Want {
-			t.Fatalf("[%d] deleteWord: bad caret position: got %d, want %d", ii, e.caret.pos.ofs, tt.Want)
+		if e.caret.start.ofs != tt.Want {
+			t.Fatalf("[%d] deleteWord: bad caret position: got %d, want %d", ii, e.caret.start.ofs, tt.Want)
 		}
 		if e.Text() != tt.Result {
 			t.Fatalf("[%d] deleteWord: invalid result: got %q, want %q", ii, e.Text(), tt.Result)
@@ -292,7 +330,7 @@ func TestEditorDeleteWord(t *testing.T) {
 func TestEditorNoLayout(t *testing.T) {
 	var e Editor
 	e.SetText("hi!\n")
-	e.MoveCaret(1)
+	e.MoveCaret(1, 1)
 }
 
 // Generate generates a value of itself, for testing/quick.
@@ -301,10 +339,144 @@ func (editMutation) Generate(rand *rand.Rand, size int) reflect.Value {
 	return reflect.ValueOf(t)
 }
 
+// TestSelect tests the selection code. It lays out an editor with several
+// lines in it, selects some text, verifies the selection, resizes the editor
+// to make it much narrower (which makes the lines in the editor reflow), and
+// then verifies that the updated (col, line) positions of the selected text
+// are where we expect.
+func TestSelect(t *testing.T) {
+	e := new(Editor)
+	e.SetText(`a123456789a
+b123456789b
+c123456789c
+d123456789d
+e123456789e
+f123456789f
+g123456789g
+`)
+
+	gtx := layout.Context{Ops: new(op.Ops)}
+	cache := text.NewCache(gofont.Collection())
+	font := text.Font{}
+	fontSize := unit.Px(10)
+
+	selected := func(start, end int) string {
+		// Layout once with no events; populate e.lines.
+		gtx.Queue = nil
+		e.Layout(gtx, cache, font, fontSize)
+		_ = e.Events() // throw away any events from this layout
+
+		// Build the selection events
+		startPos, endPos := e.offsetToScreenPos2(sortInts(start, end))
+		tq := &testQueue{
+			events: []event.Event{
+				pointer.Event{
+					Buttons:  pointer.ButtonLeft,
+					Type:     pointer.Press,
+					Source:   pointer.Mouse,
+					Position: f32.Pt(textWidth(e, startPos.lineCol.Y, 0, startPos.lineCol.X), textHeight(e, startPos.lineCol.Y)),
+				},
+				pointer.Event{
+					Type:     pointer.Release,
+					Source:   pointer.Mouse,
+					Position: f32.Pt(textWidth(e, endPos.lineCol.Y, 0, endPos.lineCol.X), textHeight(e, endPos.lineCol.Y)),
+				},
+			},
+		}
+		gtx.Queue = tq
+
+		e.Layout(gtx, cache, font, fontSize)
+		for _, evt := range e.Events() {
+			switch evt.(type) {
+			case SelectEvent:
+				return e.SelectedText()
+			}
+		}
+		return ""
+	}
+
+	type testCase struct {
+		// input text offsets
+		start, end int
+
+		// expected selected text
+		selection string
+		// expected line/col positions of selection after resize
+		startPos, endPos screenPos
+	}
+
+	for n, tst := range []testCase{
+		{0, 1, "a", screenPos{}, screenPos{Y: 0, X: 1}},
+		{0, 4, "a123", screenPos{}, screenPos{Y: 0, X: 4}},
+		{0, 11, "a123456789a", screenPos{}, screenPos{Y: 1, X: 5}},
+		{2, 6, "2345", screenPos{Y: 0, X: 2}, screenPos{Y: 1, X: 0}},
+		{41, 66, "56789d\ne123456789e\nf12345", screenPos{Y: 6, X: 5}, screenPos{Y: 11, X: 0}},
+	} {
+		// printLines(e)
+
+		gtx.Constraints = layout.Exact(image.Pt(100, 100))
+		if got := selected(tst.start, tst.end); got != tst.selection {
+			t.Errorf("Test %d pt1: Expected %q, got %q", n, tst.selection, got)
+			continue
+		}
+
+		// Constrain the editor to roughly 6 columns wide and redraw
+		gtx.Constraints = layout.Exact(image.Pt(36, 36))
+		// Keep existing selection
+		gtx.Queue = nil
+		e.Layout(gtx, cache, font, fontSize)
+
+		if e.caret.end.lineCol != tst.startPos || e.caret.start.lineCol != tst.endPos {
+			t.Errorf("Test %d pt2: Expected %#v, %#v; got %#v, %#v",
+				n,
+				e.caret.end.lineCol, e.caret.start.lineCol,
+				tst.startPos, tst.endPos)
+			continue
+		}
+
+		// printLines(e)
+	}
+}
+
+func textWidth(e *Editor, lineNum, colStart, colEnd int) float32 {
+	var w fixed.Int26_6
+	advances := e.lines[lineNum].Layout.Advances
+	if colEnd > len(advances) {
+		colEnd = len(advances)
+	}
+	for _, adv := range advances[colStart:colEnd] {
+		w += adv
+	}
+	return float32(w.Floor())
+}
+
+func textHeight(e *Editor, lineNum int) float32 {
+	var h fixed.Int26_6
+	for _, line := range e.lines[0:lineNum] {
+		h += line.Ascent + line.Descent
+	}
+	return float32(h.Floor() + 1)
+}
+
 type testQueue struct {
 	events []event.Event
 }
 
 func (q *testQueue) Events(_ event.Tag) []event.Event {
 	return q.events
+}
+
+func printLines(e *Editor) {
+	for n, line := range e.lines {
+		text := strings.TrimSuffix(line.Layout.Text, "\n")
+		fmt.Printf("%d: %s\n", n, text)
+	}
+}
+
+// sortInts returns a and b sorted such that a2 <= b2.
+func sortInts(a, b int) (a2, b2 int) {
+	if b < a {
+		return b, a
+	}
+	return a, b
 }


### PR DESCRIPTION
- [x] Click-and-drag to select text.
- [x] Cut/Copy selected text via Shortcut-X/C
- [x] Paste text via Shortcut-V
- [x] Paste overwrites selected text
- [x] Typing overwrites selected text
- [x] A "select all" hotkey, Shortcut-A
- [x] Selection via keyboard via Shift-Arrows
- [ ] Touch support
- [x] Double-click selects a word
- [ ] Triple-click selects a line
- [x] Shift-click selects from the caret to the clicked position, or adjusts the current selection.
