### PR TITLE
internal/glimpl: [wasm] remove syscall/js

### DIFF
--- a/internal/gl/gen/gen.go
+++ b/internal/gl/gen/gen.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+func translateArgType(s string) (f string, offset string) {
+	switch s {
+	case "bool":
+		return "gioLoadBool", "8"
+	case "string":
+		return "gioLoadString", "16"
+	case "int", "int64", "uint", "Attrib", "Enum", "uintptr", "unit64":
+		return "gioLoadInt64", "8"
+	case "int32", "uint32":
+		return "gioLoadInt32", "8"
+	case "[]byte":
+		return "gioLoadSlice", "24"
+	case "float", "float64", "float32":
+		return "gioLoadFloat64", "8"
+	default:
+		return "gioLoadObject", "8"
+	}
+}
+
+func translateResultType(s string) (f string, offset string) {
+	switch s {
+	case "int", "int64", "uint", "Attrib", "Enum", "uintptr", "bool":
+		return "gioSetInt64", "8"
+	case "[4]float32", "[4]int":
+		return "gioSetArray4", "32"
+	default:
+		return "gioSetObject", "8"
+	}
+}
+
+func main() {
+
+	data, err := ioutil.ReadFile("Z:\\gio\\gio-3\\internal\\gl\\gl_syscall_js.go")
+	if err != nil {
+		panic(err)
+	}
+
+	js, err := os.Create("Z:\\gio\\gio-3\\internal\\gl\\gl_unsafe_js.js")
+	if err != nil {
+		panic(err)
+	}
+
+	golang, err := os.Create("Z:\\gio\\gio-3\\internal\\gl\\gl_unsafe_js.go")
+	if err != nil {
+		panic(err)
+	}
+
+	asm, err := os.Create("Z:\\gio\\gio-3\\internal\\gl\\gl_unsafe_js.s")
+	if err != nil {
+		panic(err)
+	}
+
+	findFunctions := regexp.MustCompile(`\(f \*FunctionCaller\) (\w+)\((.*)\) (.*?){`).FindAllSubmatch(data, -1)
+	findCalls := regexp.MustCompile(`f.Ctx.Call\((.*)\)`).FindAllSubmatch(data, -1)
+
+	typeRemover := regexp.MustCompile(`(.*)\((\w+)\)`)
+
+	writeHeader(js)
+	writeGoHeader(golang)
+
+	asm.WriteString(`// SPDX-License-Identifier: Unlicense OR MIT
+
+#include "textflag.h"
+
+`)
+
+	for i, v := range findFunctions {
+		if strings.ToUpper(string(v[1][0])) != string(v[1][0]) {
+			continue
+		}
+		if len(findCalls[i][1]) == 0 {
+			continue
+		}
+		if strings.Contains(string(v[0]), "panic") {
+			continue
+		}
+
+		for _, v := range v {
+			fmt.Println(string(v))
+		}
+		for _, v := range findCalls[i] {
+			fmt.Println(string(v))
+		}
+
+		argsRaw := strings.Split(string(v[2]), ", ")
+
+		args := make([][2]string, len(argsRaw))
+
+		for i, a := range argsRaw {
+			aa := strings.Split(a, " ")
+			args[i][0] = strings.TrimSpace(aa[0])
+
+			if len(aa) > 1 {
+				args[i][1] = aa[1]
+
+				for it := 0; it < i; it++ {
+					if args[it][1] == "" {
+						args[it][1] = strings.TrimSpace(aa[1])
+					}
+				}
+			}
+		}
+
+		var argsJS string
+		var offset = "0"
+
+		fmt.Println(args, len(args))
+
+		jsArgs := strings.Split(string(findCalls[i][1]), ",")
+
+		asmArgs := make([]string, 0, len(jsArgs))
+		goArgsNames := make([]string, 0, len(jsArgs))
+		for _, a := range jsArgs {
+			t := ""
+			for _, aa := range args {
+				if cast := typeRemover.FindAllStringSubmatch(a, -1); len(cast) >= 1 {
+					a = cast[0][2]
+				}
+				if a == "ba" {
+					a = "data"
+				}
+				a = strings.Trim(strings.TrimSpace(a), `)`)
+				fmt.Println(a, aa[0])
+				if aa[0] == a {
+					t = aa[1]
+					break
+				}
+			}
+			isArray := false
+			if a == "f.int32Buf" && string(v[1]) == "InvalidateFramebuffer" {
+				//specal case
+				t = "Enum"
+				a = "attachment"
+				isArray = true
+			}
+			if t == "" {
+				switch a {
+				case "nil":
+					argsJS += fmt.Sprintf("\t\t\t\tundefined,\n")
+				case "0":
+					argsJS += fmt.Sprintf("\t\t\t\t0,\n")
+				}
+				continue
+			}
+			f, o := translateArgType(t)
+
+			if t == "float32" {
+				t = "float64"
+			}
+			asmArgs = append(asmArgs, a+" "+t)
+
+			if t == "float64" {
+				a = "float64(" + a + ")"
+			}
+			goArgsNames = append(goArgsNames, a)
+
+			if isArray {
+				argsJS += fmt.Sprintf("\t\t\t\t[%s(sp+%s)],\n", f, offset)
+			} else {
+				argsJS += fmt.Sprintf("\t\t\t\t%s((sp)+%s),\n", f, offset)
+			}
+			offset += "+" + o
+		}
+
+		resultJS := ""
+		resultGo := ""
+		resultGoType := ""
+		if len(v) > 3 {
+			result := strings.TrimSpace(string(v[3]))
+			if len(result) > 0 {
+				f, _ := translateResultType(result)
+
+				resultGoType = result
+				resultJS = fmt.Sprintf("%s((go._inst.exports.getsp() >>> 0)+%s, r)", f, offset)
+				resultGo = "return "
+			}
+			if strings.Contains(string(v[1]), "Delete") {
+				resultJS = fmt.Sprintf("gioDeleteObject(sp)")
+			}
+		}
+
+		argsJS = strings.Trim(argsJS, ",")
+
+		call := strings.Split(string(findCalls[i][1]), `, `)
+
+		fmt.Fprintf(js, `
+         // %s
+		 "gioui.org/internal/gl.%s": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.%s(
+%s			);
+
+            %s
+        },`, strings.TrimSpace(strings.TrimRight(string(v[0]), `{`)), "asm"+string(v[1]), strings.Replace(strings.Replace(call[0], `"`, "", -1), `)`, ``, -1), argsJS, resultJS)
+
+		fmt.Fprintf(golang, `
+//go:noescape
+func %s(%s) %s
+
+func %s
+	%s%s(%s)
+}
+`, "asm"+string(v[1]), strings.Join(asmArgs, ", "), resultGoType, v[0], resultGo, "asm"+string(v[1]), strings.Join(goArgsNames, ", "))
+
+		fmt.Fprintf(asm, `TEXT ·%s(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+`, "asm"+string(v[1]))
+	}
+	writeEnd(js)
+}
+
+func writeHeader(f io.StringWriter) {
+	f.WriteString(`(() => {
+
+    // webgl is the array which handles the WebGL context. See InitGL function.
+    let webgl = 0;
+
+    // textDecoder holds the TextDecoder used for encode string.
+    let textDecoder = new TextDecoder("utf-8");
+
+    // invalidateBuffer is re-use when you call invalidateBuffer().
+    let invalidateBuffer = new Int32Array(1);
+
+    // hold values from JS
+    let values = [undefined]
+    let valuesPool = []
+
+    // Offset* is the byte-size of each type (matches with Reflect.Sizeof()).
+    const OffsetContextIndex = 8;
+    const OffsetInt64 = 8;
+    const OffsetFloat64 = 8;
+    const OffsetJSValue = 8;
+    const OffsetString = 16;
+    const OffsetSlice = 24;
+
+	globalThis.setUnsafeGL = (gl) => {
+        webgl = gl
+    }
+
+    const gioLoadBool = (addr) => {
+        return gioLoadInt64(addr) > 0
+    }
+    const gioLoadInt64 = (addr) => {
+        return go.mem.getUint32(addr + 8, true) + go.mem.getInt32(addr + 12, true) * 4294967296;
+    }
+    const gioLoadInt32 = (addr) => {
+        return go.mem.getUint32(addr + 8, true);
+    }
+    const gioLoadObject = (addr) => {
+        return values[gioLoadInt64(addr)];
+    }
+    const gioLoadString = (addr) => {
+        return textDecoder.decode(new DataView(go._inst.exports.mem.buffer, gioLoadInt64(addr), gioLoadInt64(addr + 8)));
+    }
+    const gioLoadSlice = (addr) => {
+        const s = new Uint8Array(go._inst.exports.mem.buffer, gioLoadInt64(addr), gioLoadInt64(addr + 8))
+        if (s.byteLength === 0) {
+            return null
+        }
+        return s
+    }
+    const gioLoadFloat64 = (addr) => {
+        return go.mem.getFloat64(addr + 8, true);
+    }
+    const gioLoadFloat32 = (addr) => {
+        return go.mem.getFloat32(addr + 4, true);
+    }
+
+    const gioSetObject = (addr, v) => {
+        let id = 0;
+        if (v !== undefined && v !== null && v !== false) {
+            id = valuesPool.pop();
+            if (id !== undefined) {
+                values[id] = v;
+            } else {
+                id = values.push(v) - 1;
+            }
+        }
+
+        gioSetInt64(addr, id)
+    }
+    const gioSetInt64 = (addr, v) => {
+		if (v === true) {
+			v = 1;
+		}
+        go.mem.setUint32(addr + 8 + 4, 0, true);
+        go.mem.setUint32(addr + 8, v, true);
+    }
+    const gioSetArray4 = (addr, r) => {
+        for (let i = 0; i < r.length; i++) {
+            gioSetInt64(addr, r[i])
+            addr += 8
+        }
+    }
+
+	const gioDeleteObject = (addr) => {
+		valuesPool.push(gioLoadInt64(addr));
+	}
+
+    Object.assign(go.importObject.go, {`)
+}
+
+func writeEnd(file io.StringWriter) {
+	file.WriteString(`
+	})
+})();`)
+}
+
+func writeGoHeader(file io.StringWriter) {
+	file.WriteString(`//+build unsafe
+// SPDX-License-Identifier: Unlicense OR MIT
+
+package gl
+
+import (
+	"syscall/js"
+)
+
+type FunctionCaller struct {}
+
+func NewFunctionCaller(ctx Context) *FunctionCaller {
+	js.Global().Call("setUnsafeGL", js.Value(ctx))
+	return &FunctionCaller{}
+}
+`)
+
+}

--- a/internal/gl/gl_js.go
+++ b/internal/gl/gl_js.go
@@ -9,26 +9,24 @@ import (
 )
 
 type Functions struct {
-	Ctx                             js.Value
-	EXT_disjoint_timer_query        js.Value
-	EXT_disjoint_timer_query_webgl2 js.Value
+	Ctx                         js.Value
+	ExtDisjointTimerQuery       js.Value
+	ExtDisjointTimerQueryWebgl2 js.Value
 
-	// Cached reference to the Uint8Array JS type.
-	uint8Array js.Value
-
-	// Cached JS arrays.
-	arrayBuf js.Value
-	int32Buf js.Value
+	*FunctionCaller
 
 	isWebGL2 bool
 }
 
-type Context js.Value
+type (
+	Context js.Value
+	Query   js.Value
+)
 
 func NewFunctions(ctx Context, forceES bool) (*Functions, error) {
 	f := &Functions{
-		Ctx:        js.Value(ctx),
-		uint8Array: js.Global().Get("Uint8Array"),
+		Ctx:            js.Value(ctx),
+		FunctionCaller: NewFunctionCaller(ctx),
 	}
 	if err := f.Init(); err != nil {
 		return nil, err
@@ -40,7 +38,7 @@ func (f *Functions) Init() error {
 	webgl2Class := js.Global().Get("WebGL2RenderingContext")
 	f.isWebGL2 = !webgl2Class.IsUndefined() && f.Ctx.InstanceOf(webgl2Class)
 	if !f.isWebGL2 {
-		f.EXT_disjoint_timer_query = f.getExtension("EXT_disjoint_timer_query")
+		f.ExtDisjointTimerQuery = f.getExtension("EXT_disjoint_timer_query")
 		if f.getExtension("OES_texture_half_float").IsNull() && f.getExtension("OES_texture_float").IsNull() {
 			return errors.New("gl: no support for neither OES_texture_half_float nor OES_texture_float")
 		}
@@ -49,7 +47,7 @@ func (f *Functions) Init() error {
 		}
 	} else {
 		// WebGL2 extensions.
-		f.EXT_disjoint_timer_query_webgl2 = f.getExtension("EXT_disjoint_timer_query_webgl2")
+		f.ExtDisjointTimerQueryWebgl2 = f.getExtension("EXT_disjoint_timer_query_webgl2")
 		if f.getExtension("EXT_color_buffer_half_float").IsNull() && f.getExtension("EXT_color_buffer_float").IsNull() {
 			return errors.New("gl: no support for neither EXT_color_buffer_half_float nor EXT_color_buffer_float")
 		}
@@ -60,206 +58,75 @@ func (f *Functions) Init() error {
 func (f *Functions) getExtension(name string) js.Value {
 	return f.Ctx.Call("getExtension", name)
 }
-
-func (f *Functions) ActiveTexture(t Enum) {
-	f.Ctx.Call("activeTexture", int(t))
-}
-func (f *Functions) AttachShader(p Program, s Shader) {
-	f.Ctx.Call("attachShader", js.Value(p), js.Value(s))
-}
-func (f *Functions) BeginQuery(target Enum, query Query) {
-	if !f.EXT_disjoint_timer_query_webgl2.IsNull() {
-		f.Ctx.Call("beginQuery", int(target), js.Value(query))
-	} else {
-		f.EXT_disjoint_timer_query.Call("beginQueryEXT", int(target), js.Value(query))
-	}
-}
-func (f *Functions) BindAttribLocation(p Program, a Attrib, name string) {
-	f.Ctx.Call("bindAttribLocation", js.Value(p), int(a), name)
-}
-func (f *Functions) BindBuffer(target Enum, b Buffer) {
-	f.Ctx.Call("bindBuffer", int(target), js.Value(b))
-}
-func (f *Functions) BindBufferBase(target Enum, index int, b Buffer) {
-	f.Ctx.Call("bindBufferBase", int(target), index, js.Value(b))
-}
-func (f *Functions) BindFramebuffer(target Enum, fb Framebuffer) {
-	f.Ctx.Call("bindFramebuffer", int(target), js.Value(fb))
-}
-func (f *Functions) BindRenderbuffer(target Enum, rb Renderbuffer) {
-	f.Ctx.Call("bindRenderbuffer", int(target), js.Value(rb))
-}
-func (f *Functions) BindTexture(target Enum, t Texture) {
-	f.Ctx.Call("bindTexture", int(target), js.Value(t))
-}
-func (f *Functions) BindImageTexture(unit int, t Texture, level int, layered bool, layer int, access, format Enum) {
-	panic("not implemented")
-}
-func (f *Functions) BindVertexArray(a VertexArray) {
-	panic("not supported")
-}
-func (f *Functions) BlendEquation(mode Enum) {
-	f.Ctx.Call("blendEquation", int(mode))
-}
-func (f *Functions) BlendFuncSeparate(srcRGB, dstRGB, srcA, dstA Enum) {
-	f.Ctx.Call("blendFunc", int(srcRGB), int(dstRGB), int(srcA), int(dstA))
-}
-func (f *Functions) BufferData(target Enum, size int, usage Enum, data []byte) {
-	if data == nil {
-		f.Ctx.Call("bufferData", int(target), size, int(usage))
-	} else {
-		if len(data) != size {
-			panic("size mismatch")
-		}
-		f.Ctx.Call("bufferData", int(target), f.byteArrayOf(data), int(usage))
-	}
-}
-func (f *Functions) BufferSubData(target Enum, offset int, src []byte) {
-	f.Ctx.Call("bufferSubData", int(target), offset, f.byteArrayOf(src))
-}
-func (f *Functions) CheckFramebufferStatus(target Enum) Enum {
-	return Enum(f.Ctx.Call("checkFramebufferStatus", int(target)).Int())
-}
-func (f *Functions) Clear(mask Enum) {
-	f.Ctx.Call("clear", int(mask))
-}
-func (f *Functions) ClearColor(red, green, blue, alpha float32) {
-	f.Ctx.Call("clearColor", red, green, blue, alpha)
-}
-func (f *Functions) ClearDepthf(d float32) {
-	f.Ctx.Call("clearDepth", d)
-}
-func (f *Functions) CompileShader(s Shader) {
-	f.Ctx.Call("compileShader", js.Value(s))
-}
-func (f *Functions) CopyTexSubImage2D(target Enum, level, xoffset, yoffset, x, y, width, height int) {
-	f.Ctx.Call("copyTexSubImage2D", int(target), level, xoffset, yoffset, x, y, width, height)
-}
-func (f *Functions) CreateBuffer() Buffer {
-	return Buffer(f.Ctx.Call("createBuffer"))
-}
-func (f *Functions) CreateFramebuffer() Framebuffer {
-	return Framebuffer(f.Ctx.Call("createFramebuffer"))
-}
-func (f *Functions) CreateProgram() Program {
-	return Program(f.Ctx.Call("createProgram"))
-}
 func (f *Functions) CreateQuery() Query {
 	return Query(f.Ctx.Call("createQuery"))
 }
-func (f *Functions) CreateRenderbuffer() Renderbuffer {
-	return Renderbuffer(f.Ctx.Call("createRenderbuffer"))
+func (f *Functions) BeginQuery(target Enum, query Query) {
+	if !f.ExtDisjointTimerQueryWebgl2.IsNull() {
+		f.Ctx.Call("beginQuery", int(target), js.Value(query))
+	} else {
+		f.ExtDisjointTimerQuery.Call("beginQueryEXT", int(target), js.Value(query))
+	}
 }
-func (f *Functions) CreateShader(ty Enum) Shader {
-	return Shader(f.Ctx.Call("createShader", int(ty)))
-}
-func (f *Functions) CreateTexture() Texture {
-	return Texture(f.Ctx.Call("createTexture"))
-}
-func (f *Functions) CreateVertexArray() VertexArray {
-	panic("not supported")
-}
-func (f *Functions) DeleteBuffer(v Buffer) {
-	f.Ctx.Call("deleteBuffer", js.Value(v))
-}
-func (f *Functions) DeleteFramebuffer(v Framebuffer) {
-	f.Ctx.Call("deleteFramebuffer", js.Value(v))
-}
-func (f *Functions) DeleteProgram(p Program) {
-	f.Ctx.Call("deleteProgram", js.Value(p))
+func (f *Functions) BufferData(target Enum, size int, usage Enum, data []byte) {
+	if data == nil {
+		f.FunctionCaller.BufferDataSize(target, size, usage)
+	} else {
+		f.FunctionCaller.BufferData(target, usage, data)
+	}
 }
 func (f *Functions) DeleteQuery(query Query) {
-	if !f.EXT_disjoint_timer_query_webgl2.IsNull() {
+	if !f.ExtDisjointTimerQueryWebgl2.IsNull() {
 		f.Ctx.Call("deleteQuery", js.Value(query))
 	} else {
-		f.EXT_disjoint_timer_query.Call("deleteQueryEXT", js.Value(query))
+		f.ExtDisjointTimerQuery.Call("deleteQueryEXT", js.Value(query))
 	}
-}
-func (f *Functions) DeleteShader(s Shader) {
-	f.Ctx.Call("deleteShader", js.Value(s))
-}
-func (f *Functions) DeleteRenderbuffer(v Renderbuffer) {
-	f.Ctx.Call("deleteRenderbuffer", js.Value(v))
-}
-func (f *Functions) DeleteTexture(v Texture) {
-	f.Ctx.Call("deleteTexture", js.Value(v))
-}
-func (f *Functions) DeleteVertexArray(a VertexArray) {
-	panic("not implemented")
-}
-func (f *Functions) DepthFunc(fn Enum) {
-	f.Ctx.Call("depthFunc", int(fn))
-}
-func (f *Functions) DepthMask(mask bool) {
-	f.Ctx.Call("depthMask", mask)
-}
-func (f *Functions) DisableVertexAttribArray(a Attrib) {
-	f.Ctx.Call("disableVertexAttribArray", int(a))
-}
-func (f *Functions) Disable(cap Enum) {
-	f.Ctx.Call("disable", int(cap))
-}
-func (f *Functions) DrawArrays(mode Enum, first, count int) {
-	f.Ctx.Call("drawArrays", int(mode), first, count)
-}
-func (f *Functions) DrawElements(mode Enum, count int, ty Enum, offset int) {
-	f.Ctx.Call("drawElements", int(mode), count, int(ty), offset)
-}
-func (f *Functions) DispatchCompute(x, y, z int) {
-	panic("not implemented")
-}
-func (f *Functions) Enable(cap Enum) {
-	f.Ctx.Call("enable", int(cap))
-}
-func (f *Functions) EnableVertexAttribArray(a Attrib) {
-	f.Ctx.Call("enableVertexAttribArray", int(a))
 }
 func (f *Functions) EndQuery(target Enum) {
-	if !f.EXT_disjoint_timer_query_webgl2.IsNull() {
+	if !f.ExtDisjointTimerQueryWebgl2.IsNull() {
 		f.Ctx.Call("endQuery", int(target))
 	} else {
-		f.EXT_disjoint_timer_query.Call("endQueryEXT", int(target))
+		f.ExtDisjointTimerQuery.Call("endQueryEXT", int(target))
 	}
 }
-func (f *Functions) Finish() {
-	f.Ctx.Call("finish")
+func (f *Functions) GetQueryObjectuiv(query Query, pname Enum) uint {
+	if !f.ExtDisjointTimerQueryWebgl2.IsNull() {
+		return uint(paramVal(f.Ctx.Call("getQueryParameter", js.Value(query), int(pname))))
+	} else {
+		return uint(paramVal(f.ExtDisjointTimerQuery.Call("getQueryObjectEXT", js.Value(query), int(pname))))
+	}
 }
-func (f *Functions) Flush() {
-	f.Ctx.Call("flush")
-}
-func (f *Functions) FramebufferRenderbuffer(target, attachment, renderbuffertarget Enum, renderbuffer Renderbuffer) {
-	f.Ctx.Call("framebufferRenderbuffer", int(target), int(attachment), int(renderbuffertarget), js.Value(renderbuffer))
-}
-func (f *Functions) FramebufferTexture2D(target, attachment, texTarget Enum, t Texture, level int) {
-	f.Ctx.Call("framebufferTexture2D", int(target), int(attachment), int(texTarget), js.Value(t), level)
+func (f *Functions) InvalidateFramebuffer(target, attachment Enum) {
+	if !f.isWebGL2 {
+		// WebGL 1 doesn't have that function
+		return
+	}
+	f.FunctionCaller.InvalidateFramebuffer(target, attachment)
 }
 func (f *Functions) GetError() Enum {
 	// Avoid slow getError calls. See gio#179.
 	return 0
-}
-func (f *Functions) GetRenderbufferParameteri(target, pname Enum) int {
-	return paramVal(f.Ctx.Call("getRenderbufferParameteri", int(pname)))
 }
 func (f *Functions) GetFramebufferAttachmentParameteri(target, attachment, pname Enum) int {
 	if !f.isWebGL2 && pname == FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING {
 		// FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING is only available on WebGL 2
 		return LINEAR
 	}
-	return paramVal(f.Ctx.Call("getFramebufferAttachmentParameter", int(target), int(attachment), int(pname)))
+	return f.FunctionCaller.GetFramebufferAttachmentParameteri(target, attachment, pname)
 }
 func (f *Functions) GetBinding(pname Enum) Object {
-	obj := f.Ctx.Call("getParameter", int(pname))
-	if !obj.Truthy() {
+	obj := f.FunctionCaller.GetBinding(pname)
+	if !obj.valid() {
 		return Object{}
 	}
-	return Object(obj)
+	return obj
 }
 func (f *Functions) GetBindingi(pname Enum, idx int) Object {
-	obj := f.Ctx.Call("getIndexedParameter", int(pname), idx)
-	if !obj.Truthy() {
+	obj := f.FunctionCaller.GetBindingi(pname, idx)
+	if !obj.valid() {
 		return Object{}
 	}
-	return Object(obj)
+	return obj
 }
 func (f *Functions) GetInteger(pname Enum) int {
 	if !f.isWebGL2 {
@@ -268,45 +135,18 @@ func (f *Functions) GetInteger(pname Enum) int {
 			return 0 // PACK_ROW_LENGTH and UNPACK_ROW_LENGTH is only available on WebGL 2
 		}
 	}
-	return paramVal(f.Ctx.Call("getParameter", int(pname)))
+	return f.FunctionCaller.GetInteger(pname)
 }
 func (f *Functions) GetFloat(pname Enum) float32 {
-	return float32(f.Ctx.Call("getParameter", int(pname)).Float())
+	return f.FunctionCaller.GetFloat(pname)
 }
+
 func (f *Functions) GetInteger4(pname Enum) [4]int {
-	arr := f.Ctx.Call("getParameter", int(pname))
-	var res [4]int
-	for i := range res {
-		res[i] = arr.Index(i).Int()
-	}
-	return res
+	return f.FunctionCaller.GetInteger4(pname)
 }
+
 func (f *Functions) GetFloat4(pname Enum) [4]float32 {
-	arr := f.Ctx.Call("getParameter", int(pname))
-	var res [4]float32
-	for i := range res {
-		res[i] = float32(arr.Index(i).Float())
-	}
-	return res
-}
-func (f *Functions) GetProgrami(p Program, pname Enum) int {
-	return paramVal(f.Ctx.Call("getProgramParameter", js.Value(p), int(pname)))
-}
-func (f *Functions) GetProgramInfoLog(p Program) string {
-	return f.Ctx.Call("getProgramInfoLog", js.Value(p)).String()
-}
-func (f *Functions) GetQueryObjectuiv(query Query, pname Enum) uint {
-	if !f.EXT_disjoint_timer_query_webgl2.IsNull() {
-		return uint(paramVal(f.Ctx.Call("getQueryParameter", js.Value(query), int(pname))))
-	} else {
-		return uint(paramVal(f.EXT_disjoint_timer_query.Call("getQueryObjectEXT", js.Value(query), int(pname))))
-	}
-}
-func (f *Functions) GetShaderi(s Shader, pname Enum) int {
-	return paramVal(f.Ctx.Call("getShaderParameter", js.Value(s), int(pname)))
-}
-func (f *Functions) GetShaderInfoLog(s Shader) string {
-	return f.Ctx.Call("getShaderInfoLog", js.Value(s)).String()
+	return f.FunctionCaller.GetFloat4(pname)
 }
 func (f *Functions) GetString(pname Enum) string {
 	switch pname {
@@ -321,125 +161,44 @@ func (f *Functions) GetString(pname Enum) string {
 		return f.Ctx.Call("getParameter", int(pname)).String()
 	}
 }
-func (f *Functions) GetUniformBlockIndex(p Program, name string) uint {
-	return uint(paramVal(f.Ctx.Call("getUniformBlockIndex", js.Value(p), name)))
-}
-func (f *Functions) GetUniformLocation(p Program, name string) Uniform {
-	return Uniform(f.Ctx.Call("getUniformLocation", js.Value(p), name))
-}
-func (f *Functions) GetVertexAttrib(index int, pname Enum) int {
-	return paramVal(f.Ctx.Call("getVertexAttrib", index, int(pname)))
-}
 func (f *Functions) GetVertexAttribBinding(index int, pname Enum) Object {
-	obj := f.Ctx.Call("getVertexAttrib", index, int(pname))
-	if !obj.Truthy() {
+	obj := f.FunctionCaller.GetVertexAttribBinding(index, pname)
+	if !obj.valid() {
 		return Object{}
 	}
-	return Object(obj)
-}
-func (f *Functions) GetVertexAttribPointer(index int, pname Enum) uintptr {
-	return uintptr(f.Ctx.Call("getVertexAttribOffset", index, int(pname)).Int())
-}
-func (f *Functions) InvalidateFramebuffer(target, attachment Enum) {
-	fn := f.Ctx.Get("invalidateFramebuffer")
-	if !fn.IsUndefined() {
-		if f.int32Buf.IsUndefined() {
-			f.int32Buf = js.Global().Get("Int32Array").New(1)
-		}
-		f.int32Buf.SetIndex(0, int32(attachment))
-		f.Ctx.Call("invalidateFramebuffer", int(target), f.int32Buf)
-	}
-}
-func (f *Functions) IsEnabled(cap Enum) bool {
-	return f.Ctx.Call("isEnabled", int(cap)).Truthy()
-}
-func (f *Functions) LinkProgram(p Program) {
-	f.Ctx.Call("linkProgram", js.Value(p))
-}
-func (f *Functions) PixelStorei(pname Enum, param int) {
-	f.Ctx.Call("pixelStorei", int(pname), param)
-}
-func (f *Functions) MemoryBarrier(barriers Enum) {
-	panic("not implemented")
-}
-func (f *Functions) MapBufferRange(target Enum, offset, length int, access Enum) []byte {
-	panic("not implemented")
-}
-func (f *Functions) RenderbufferStorage(target, internalformat Enum, width, height int) {
-	f.Ctx.Call("renderbufferStorage", int(target), int(internalformat), width, height)
-}
-func (f *Functions) ReadPixels(x, y, width, height int, format, ty Enum, data []byte) {
-	ba := f.byteArrayOf(data)
-	f.Ctx.Call("readPixels", x, y, width, height, int(format), int(ty), ba)
-	js.CopyBytesToGo(data, ba)
-}
-func (f *Functions) Scissor(x, y, width, height int32) {
-	f.Ctx.Call("scissor", x, y, width, height)
-}
-func (f *Functions) ShaderSource(s Shader, src string) {
-	f.Ctx.Call("shaderSource", js.Value(s), src)
-}
-func (f *Functions) TexImage2D(target Enum, level int, internalFormat Enum, width, height int, format, ty Enum) {
-	f.Ctx.Call("texImage2D", int(target), int(level), int(internalFormat), int(width), int(height), 0, int(format), int(ty), nil)
-}
-func (f *Functions) TexStorage2D(target Enum, levels int, internalFormat Enum, width, height int) {
-	f.Ctx.Call("texStorage2D", int(target), levels, int(internalFormat), width, height)
-}
-func (f *Functions) TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
-	f.Ctx.Call("texSubImage2D", int(target), level, x, y, width, height, int(format), int(ty), f.byteArrayOf(data))
-}
-func (f *Functions) TexParameteri(target, pname Enum, param int) {
-	f.Ctx.Call("texParameteri", int(target), int(pname), int(param))
-}
-func (f *Functions) UniformBlockBinding(p Program, uniformBlockIndex uint, uniformBlockBinding uint) {
-	f.Ctx.Call("uniformBlockBinding", js.Value(p), int(uniformBlockIndex), int(uniformBlockBinding))
-}
-func (f *Functions) Uniform1f(dst Uniform, v float32) {
-	f.Ctx.Call("uniform1f", js.Value(dst), v)
-}
-func (f *Functions) Uniform1i(dst Uniform, v int) {
-	f.Ctx.Call("uniform1i", js.Value(dst), v)
-}
-func (f *Functions) Uniform2f(dst Uniform, v0, v1 float32) {
-	f.Ctx.Call("uniform2f", js.Value(dst), v0, v1)
-}
-func (f *Functions) Uniform3f(dst Uniform, v0, v1, v2 float32) {
-	f.Ctx.Call("uniform3f", js.Value(dst), v0, v1, v2)
-}
-func (f *Functions) Uniform4f(dst Uniform, v0, v1, v2, v3 float32) {
-	f.Ctx.Call("uniform4f", js.Value(dst), v0, v1, v2, v3)
-}
-func (f *Functions) UseProgram(p Program) {
-	f.Ctx.Call("useProgram", js.Value(p))
-}
-func (f *Functions) UnmapBuffer(target Enum) bool {
-	panic("not implemented")
-}
-func (f *Functions) VertexAttribPointer(dst Attrib, size int, ty Enum, normalized bool, stride, offset int) {
-	f.Ctx.Call("vertexAttribPointer", int(dst), size, int(ty), normalized, stride, offset)
-}
-func (f *Functions) Viewport(x, y, width, height int) {
-	f.Ctx.Call("viewport", x, y, width, height)
+	return obj
 }
 
-func (f *Functions) byteArrayOf(data []byte) js.Value {
-	if len(data) == 0 {
-		return js.Null()
-	}
-	f.resizeByteBuffer(len(data))
-	ba := f.uint8Array.New(f.arrayBuf, int(0), int(len(data)))
-	js.CopyBytesToJS(ba, data)
-	return ba
+func (f *Functions) GetProgramInfoLog(p Program) string {
+	return ""
+}
+func (f *Functions) GetShaderInfoLog(s Shader) string {
+	return ""
 }
 
-func (f *Functions) resizeByteBuffer(n int) {
-	if n == 0 {
-		return
-	}
-	if !f.arrayBuf.IsUndefined() && f.arrayBuf.Length() >= n {
-		return
-	}
-	f.arrayBuf = js.Global().Get("ArrayBuffer").New(n)
+func (f *FunctionCaller) CreateVertexArray() VertexArray {
+	panic("not supported")
+}
+func (f *FunctionCaller) DeleteVertexArray(a VertexArray) {
+	panic("not implemented")
+}
+func (f *FunctionCaller) DispatchCompute(x, y, z int) {
+	panic("not implemented")
+}
+func (f *FunctionCaller) MemoryBarrier(barriers Enum) {
+	panic("not implemented")
+}
+func (f *FunctionCaller) MapBufferRange(target Enum, offset, length int, access Enum) []byte {
+	panic("not implemented")
+}
+func (f *FunctionCaller) UnmapBuffer(target Enum) bool {
+	panic("not implemented")
+}
+func (f *FunctionCaller) BindImageTexture(unit int, t Texture, level int, layered bool, layer int, access, format Enum) {
+	panic("not implemented")
+}
+func (f *FunctionCaller) BindVertexArray(a VertexArray) {
+	panic("not supported")
 }
 
 func paramVal(v js.Value) int {

--- a/internal/gl/gl_syscall_js.go
+++ b/internal/gl/gl_syscall_js.go
@@ -1,0 +1,307 @@
+//go:build !unsafe
+// +build !unsafe
+
+// SPDX-License-Identifier: Unlicense OR MIT
+
+package gl
+
+import (
+	"syscall/js"
+)
+
+type FunctionCaller struct {
+	Ctx js.Value
+
+	// Cached reference to the Uint8Array JS type.
+	uint8Array js.Value
+
+	// Cached JS arrays.
+	arrayBuf js.Value
+	int32Buf js.Value
+
+	isWebGL2 bool
+}
+
+func NewFunctionCaller(ctx Context) *FunctionCaller {
+	return &FunctionCaller{
+		Ctx:        js.Value(ctx),
+		uint8Array: js.Global().Get("Uint8Array"),
+	}
+}
+
+func (f *FunctionCaller) ActiveTexture(t Enum) {
+	f.Ctx.Call("activeTexture", int(t))
+}
+func (f *FunctionCaller) AttachShader(p Program, s Shader) {
+	f.Ctx.Call("attachShader", js.Value(p), js.Value(s))
+}
+func (f *FunctionCaller) BindAttribLocation(p Program, a Attrib, name string) {
+	f.Ctx.Call("bindAttribLocation", js.Value(p), int(a), name)
+}
+func (f *FunctionCaller) BindBuffer(target Enum, b Buffer) {
+	f.Ctx.Call("bindBuffer", int(target), js.Value(b))
+}
+func (f *FunctionCaller) BindBufferBase(target Enum, index int, b Buffer) {
+	f.Ctx.Call("bindBufferBase", int(target), index, js.Value(b))
+}
+func (f *FunctionCaller) BindFramebuffer(target Enum, fb Framebuffer) {
+	f.Ctx.Call("bindFramebuffer", int(target), js.Value(fb))
+}
+func (f *FunctionCaller) BindRenderbuffer(target Enum, rb Renderbuffer) {
+	f.Ctx.Call("bindRenderbuffer", int(target), js.Value(rb))
+}
+func (f *FunctionCaller) BindTexture(target Enum, t Texture) {
+	f.Ctx.Call("bindTexture", int(target), js.Value(t))
+}
+func (f *FunctionCaller) BlendEquation(mode Enum) {
+	f.Ctx.Call("blendEquation", int(mode))
+}
+func (f *FunctionCaller) BlendFuncSeparate(srcRGB, dstRGB, srcA, dstA Enum) {
+	f.Ctx.Call("blendFunc", int(srcRGB), int(dstRGB), int(srcA), int(dstA))
+}
+func (f *FunctionCaller) BufferData(target Enum, usage Enum, data []byte) {
+	f.Ctx.Call("bufferData", int(target), f.byteArrayOf(data), int(usage))
+}
+func (f *FunctionCaller) BufferDataSize(target Enum, size int, usage Enum) {
+	f.Ctx.Call("bufferData", int(target), size, int(usage))
+}
+func (f *FunctionCaller) BufferSubData(target Enum, offset int, src []byte) {
+	f.Ctx.Call("bufferSubData", int(target), offset, f.byteArrayOf(src))
+}
+func (f *FunctionCaller) CheckFramebufferStatus(target Enum) Enum {
+	return Enum(f.Ctx.Call("checkFramebufferStatus", int(target)).Int())
+}
+func (f *FunctionCaller) Clear(mask Enum) {
+	f.Ctx.Call("clear", int(mask))
+}
+func (f *FunctionCaller) ClearColor(red, green, blue, alpha float32) {
+	f.Ctx.Call("clearColor", red, green, blue, alpha)
+}
+func (f *FunctionCaller) ClearDepthf(d float32) {
+	f.Ctx.Call("clearDepth", d)
+}
+func (f *FunctionCaller) CompileShader(s Shader) {
+	f.Ctx.Call("compileShader", js.Value(s))
+}
+func (f *FunctionCaller) CopyTexSubImage2D(target Enum, level, xoffset, yoffset, x, y, width, height int) {
+	f.Ctx.Call("copyTexSubImage2D", int(target), level, xoffset, yoffset, x, y, width, height)
+}
+func (f *FunctionCaller) CreateBuffer() Buffer {
+	return Buffer(f.Ctx.Call("createBuffer"))
+}
+func (f *FunctionCaller) CreateFramebuffer() Framebuffer {
+	return Framebuffer(f.Ctx.Call("createFramebuffer"))
+}
+func (f *FunctionCaller) CreateProgram() Program {
+	return Program(f.Ctx.Call("createProgram"))
+}
+func (f *FunctionCaller) CreateRenderbuffer() Renderbuffer {
+	return Renderbuffer(f.Ctx.Call("createRenderbuffer"))
+}
+func (f *FunctionCaller) CreateShader(ty Enum) Shader {
+	return Shader(f.Ctx.Call("createShader", int(ty)))
+}
+func (f *FunctionCaller) CreateTexture() Texture {
+	return Texture(f.Ctx.Call("createTexture"))
+}
+func (f *FunctionCaller) DeleteBuffer(v Buffer) {
+	f.Ctx.Call("deleteBuffer", js.Value(v))
+}
+func (f *FunctionCaller) DeleteFramebuffer(v Framebuffer) {
+	f.Ctx.Call("deleteFramebuffer", js.Value(v))
+}
+func (f *FunctionCaller) DeleteProgram(p Program) {
+	f.Ctx.Call("deleteProgram", js.Value(p))
+}
+func (f *FunctionCaller) DeleteShader(s Shader) {
+	f.Ctx.Call("deleteShader", js.Value(s))
+}
+func (f *FunctionCaller) DeleteRenderbuffer(v Renderbuffer) {
+	f.Ctx.Call("deleteRenderbuffer", js.Value(v))
+}
+func (f *FunctionCaller) DeleteTexture(v Texture) {
+	f.Ctx.Call("deleteTexture", js.Value(v))
+}
+func (f *FunctionCaller) DepthFunc(fn Enum) {
+	f.Ctx.Call("depthFunc", int(fn))
+}
+func (f *FunctionCaller) DepthMask(mask bool) {
+	f.Ctx.Call("depthMask", mask)
+}
+func (f *FunctionCaller) DisableVertexAttribArray(a Attrib) {
+	f.Ctx.Call("disableVertexAttribArray", int(a))
+}
+func (f *FunctionCaller) Disable(cap Enum) {
+	f.Ctx.Call("disable", int(cap))
+}
+func (f *FunctionCaller) DrawArrays(mode Enum, first, count int) {
+	f.Ctx.Call("drawArrays", int(mode), first, count)
+}
+func (f *FunctionCaller) DrawElements(mode Enum, count int, ty Enum, offset int) {
+	f.Ctx.Call("drawElements", int(mode), count, int(ty), offset)
+}
+func (f *FunctionCaller) Enable(cap Enum) {
+	f.Ctx.Call("enable", int(cap))
+}
+func (f *FunctionCaller) EnableVertexAttribArray(a Attrib) {
+	f.Ctx.Call("enableVertexAttribArray", int(a))
+}
+func (f *FunctionCaller) Finish() {
+	f.Ctx.Call("finish")
+}
+func (f *FunctionCaller) Flush() {
+	f.Ctx.Call("flush")
+}
+func (f *FunctionCaller) FramebufferRenderbuffer(target, attachment, renderbuffertarget Enum, renderbuffer Renderbuffer) {
+	f.Ctx.Call("framebufferRenderbuffer", int(target), int(attachment), int(renderbuffertarget), js.Value(renderbuffer))
+}
+func (f *FunctionCaller) FramebufferTexture2D(target, attachment, texTarget Enum, t Texture, level int) {
+	f.Ctx.Call("framebufferTexture2D", int(target), int(attachment), int(texTarget), js.Value(t), level)
+}
+func (f *FunctionCaller) GetRenderbufferParameteri(target, pname Enum) int {
+	return paramVal(f.Ctx.Call("getRenderbufferParameteri", int(pname)))
+}
+func (f *FunctionCaller) GetFramebufferAttachmentParameteri(target, attachment, pname Enum) int {
+	return paramVal(f.Ctx.Call("getFramebufferAttachmentParameter", int(target), int(attachment), int(pname)))
+}
+func (f *FunctionCaller) GetBinding(pname Enum) Object {
+	return Object(f.Ctx.Call("getParameter", int(pname)))
+}
+func (f *FunctionCaller) GetBindingi(pname Enum, idx int) Object {
+	return Object(f.Ctx.Call("getIndexedParameter", int(pname), idx))
+}
+func (f *FunctionCaller) GetInteger(pname Enum) int {
+	return paramVal(f.Ctx.Call("getParameter", int(pname)))
+}
+func (f *FunctionCaller) GetFloat(pname Enum) float32 {
+	return float32(f.Ctx.Call("getParameter", int(pname)).Float())
+}
+func (f *FunctionCaller) GetInteger4(pname Enum) [4]int {
+	arr := f.Ctx.Call("getParameter", int(pname))
+	var res [4]int
+	for i := range res {
+		res[i] = arr.Index(i).Int()
+	}
+	return res
+}
+func (f *FunctionCaller) GetFloat4(pname Enum) [4]float32 {
+	arr := f.Ctx.Call("getParameter", int(pname))
+	var res [4]float32
+	for i := range res {
+		res[i] = float32(arr.Index(i).Float())
+	}
+	return res
+}
+func (f *FunctionCaller) GetProgrami(p Program, pname Enum) int {
+	return paramVal(f.Ctx.Call("getProgramParameter", js.Value(p), int(pname)))
+}
+func (f *FunctionCaller) GetShaderi(s Shader, pname Enum) int {
+	return paramVal(f.Ctx.Call("getShaderParameter", js.Value(s), int(pname)))
+}
+func (f *FunctionCaller) GetUniformBlockIndex(p Program, name string) uint {
+	return uint(paramVal(f.Ctx.Call("getUniformBlockIndex", js.Value(p), name)))
+}
+func (f *FunctionCaller) GetUniformLocation(p Program, name string) Uniform {
+	return Uniform(f.Ctx.Call("getUniformLocation", js.Value(p), name))
+}
+func (f *FunctionCaller) GetVertexAttrib(index int, pname Enum) int {
+	return paramVal(f.Ctx.Call("getVertexAttrib", index, int(pname)))
+}
+func (f *FunctionCaller) GetVertexAttribBinding(index int, pname Enum) Object {
+	return Object(f.Ctx.Call("getVertexAttrib", index, int(pname)))
+}
+func (f *FunctionCaller) GetVertexAttribPointer(index int, pname Enum) uintptr {
+	return uintptr(f.Ctx.Call("getVertexAttribOffset", index, int(pname)).Int())
+}
+func (f *FunctionCaller) InvalidateFramebuffer(target, attachment Enum) {
+	fn := f.Ctx.Get("invalidateFramebuffer")
+	if !fn.IsUndefined() {
+		if f.int32Buf.IsUndefined() {
+			f.int32Buf = js.Global().Get("Int32Array").New(1)
+		}
+		f.int32Buf.SetIndex(0, int32(attachment))
+		f.Ctx.Call("invalidateFramebuffer", int(target), f.int32Buf)
+	}
+}
+func (f *FunctionCaller) IsEnabled(cap Enum) bool {
+	return f.Ctx.Call("isEnabled", int(cap)).Truthy()
+}
+func (f *FunctionCaller) LinkProgram(p Program) {
+	f.Ctx.Call("linkProgram", js.Value(p))
+}
+func (f *FunctionCaller) PixelStorei(pname Enum, param int) {
+	f.Ctx.Call("pixelStorei", int(pname), param)
+}
+func (f *FunctionCaller) RenderbufferStorage(target, internalformat Enum, width, height int) {
+	f.Ctx.Call("renderbufferStorage", int(target), int(internalformat), width, height)
+}
+func (f *FunctionCaller) ReadPixels(x, y, width, height int, format, ty Enum, data []byte) {
+	ba := f.byteArrayOf(data)
+	f.Ctx.Call("readPixels", x, y, width, height, int(format), int(ty), ba)
+	js.CopyBytesToGo(data, ba)
+}
+func (f *FunctionCaller) Scissor(x, y, width, height int32) {
+	f.Ctx.Call("scissor", x, y, width, height)
+}
+func (f *FunctionCaller) ShaderSource(s Shader, src string) {
+	f.Ctx.Call("shaderSource", js.Value(s), src)
+}
+func (f *FunctionCaller) TexImage2D(target Enum, level int, internalFormat Enum, width, height int, format, ty Enum) {
+	f.Ctx.Call("texImage2D", int(target), int(level), int(internalFormat), int(width), int(height), 0, int(format), int(ty), nil)
+}
+func (f *FunctionCaller) TexStorage2D(target Enum, levels int, internalFormat Enum, width, height int) {
+	f.Ctx.Call("texStorage2D", int(target), levels, int(internalFormat), width, height)
+}
+func (f *FunctionCaller) TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
+	f.Ctx.Call("texSubImage2D", int(target), level, x, y, width, height, int(format), int(ty), f.byteArrayOf(data))
+}
+func (f *FunctionCaller) TexParameteri(target, pname Enum, param int) {
+	f.Ctx.Call("texParameteri", int(target), int(pname), int(param))
+}
+func (f *FunctionCaller) UniformBlockBinding(p Program, uniformBlockIndex uint, uniformBlockBinding uint) {
+	f.Ctx.Call("uniformBlockBinding", js.Value(p), int(uniformBlockIndex), int(uniformBlockBinding))
+}
+func (f *FunctionCaller) Uniform1f(dst Uniform, v float32) {
+	f.Ctx.Call("uniform1f", js.Value(dst), v)
+}
+func (f *FunctionCaller) Uniform1i(dst Uniform, v int) {
+	f.Ctx.Call("uniform1i", js.Value(dst), v)
+}
+func (f *FunctionCaller) Uniform2f(dst Uniform, v0, v1 float32) {
+	f.Ctx.Call("uniform2f", js.Value(dst), v0, v1)
+}
+func (f *FunctionCaller) Uniform3f(dst Uniform, v0, v1, v2 float32) {
+	f.Ctx.Call("uniform3f", js.Value(dst), v0, v1, v2)
+}
+func (f *FunctionCaller) Uniform4f(dst Uniform, v0, v1, v2, v3 float32) {
+	f.Ctx.Call("uniform4f", js.Value(dst), v0, v1, v2, v3)
+}
+func (f *FunctionCaller) UseProgram(p Program) {
+	f.Ctx.Call("useProgram", js.Value(p))
+}
+func (f *FunctionCaller) VertexAttribPointer(dst Attrib, size int, ty Enum, normalized bool, stride, offset int) {
+	f.Ctx.Call("vertexAttribPointer", int(dst), size, int(ty), normalized, stride, offset)
+}
+func (f *FunctionCaller) Viewport(x, y, width, height int) {
+	f.Ctx.Call("viewport", x, y, width, height)
+}
+
+func (f *FunctionCaller) byteArrayOf(data []byte) js.Value {
+	if len(data) == 0 {
+		return js.Null()
+	}
+	f.resizeByteBuffer(len(data))
+	ba := f.uint8Array.New(f.arrayBuf, int(0), int(len(data)))
+	js.CopyBytesToJS(ba, data)
+	return ba
+}
+
+func (f *FunctionCaller) resizeByteBuffer(n int) {
+	if n == 0 {
+		return
+	}
+	if !f.arrayBuf.IsUndefined() && f.arrayBuf.Length() >= n {
+		return
+	}
+	f.arrayBuf = js.Global().Get("ArrayBuffer").New(n)
+}

--- a/internal/gl/gl_unsafe_js.go
+++ b/internal/gl/gl_unsafe_js.go
@@ -1,0 +1,568 @@
+//+build unsafe
+// SPDX-License-Identifier: Unlicense OR MIT
+
+package gl
+
+import (
+	"syscall/js"
+)
+
+type FunctionCaller struct {}
+
+func NewFunctionCaller(ctx Context) *FunctionCaller {
+	js.Global().Call("setUnsafeGL", js.Value(ctx))
+	return &FunctionCaller{}
+}
+
+//go:noescape
+func asmActiveTexture(t Enum) 
+
+func (f *FunctionCaller) ActiveTexture(t Enum) {
+	asmActiveTexture(t)
+}
+
+//go:noescape
+func asmAttachShader(p Program, s Shader) 
+
+func (f *FunctionCaller) AttachShader(p Program, s Shader) {
+	asmAttachShader(p, s)
+}
+
+//go:noescape
+func asmBindAttribLocation(p Program, a Attrib, name string) 
+
+func (f *FunctionCaller) BindAttribLocation(p Program, a Attrib, name string) {
+	asmBindAttribLocation(p, a, name)
+}
+
+//go:noescape
+func asmBindBuffer(target Enum, b Buffer) 
+
+func (f *FunctionCaller) BindBuffer(target Enum, b Buffer) {
+	asmBindBuffer(target, b)
+}
+
+//go:noescape
+func asmBindBufferBase(target Enum, index int, b Buffer) 
+
+func (f *FunctionCaller) BindBufferBase(target Enum, index int, b Buffer) {
+	asmBindBufferBase(target, index, b)
+}
+
+//go:noescape
+func asmBindFramebuffer(target Enum, fb Framebuffer) 
+
+func (f *FunctionCaller) BindFramebuffer(target Enum, fb Framebuffer) {
+	asmBindFramebuffer(target, fb)
+}
+
+//go:noescape
+func asmBindRenderbuffer(target Enum, rb Renderbuffer) 
+
+func (f *FunctionCaller) BindRenderbuffer(target Enum, rb Renderbuffer) {
+	asmBindRenderbuffer(target, rb)
+}
+
+//go:noescape
+func asmBindTexture(target Enum, t Texture) 
+
+func (f *FunctionCaller) BindTexture(target Enum, t Texture) {
+	asmBindTexture(target, t)
+}
+
+//go:noescape
+func asmBlendEquation(mode Enum) 
+
+func (f *FunctionCaller) BlendEquation(mode Enum) {
+	asmBlendEquation(mode)
+}
+
+//go:noescape
+func asmBlendFuncSeparate(srcRGB Enum, dstRGB Enum, srcA Enum, dstA Enum) 
+
+func (f *FunctionCaller) BlendFuncSeparate(srcRGB, dstRGB, srcA, dstA Enum) {
+	asmBlendFuncSeparate(srcRGB, dstRGB, srcA, dstA)
+}
+
+//go:noescape
+func asmBufferData(target Enum, data []byte, usage Enum) 
+
+func (f *FunctionCaller) BufferData(target Enum, usage Enum, data []byte) {
+	asmBufferData(target, data, usage)
+}
+
+//go:noescape
+func asmBufferDataSize(target Enum, size int, usage Enum) 
+
+func (f *FunctionCaller) BufferDataSize(target Enum, size int, usage Enum) {
+	asmBufferDataSize(target, size, usage)
+}
+
+//go:noescape
+func asmBufferSubData(target Enum, offset int, src []byte) 
+
+func (f *FunctionCaller) BufferSubData(target Enum, offset int, src []byte) {
+	asmBufferSubData(target, offset, src)
+}
+
+//go:noescape
+func asmCheckFramebufferStatus(target Enum) Enum
+
+func (f *FunctionCaller) CheckFramebufferStatus(target Enum) Enum {
+	return asmCheckFramebufferStatus(target)
+}
+
+//go:noescape
+func asmClear(mask Enum) 
+
+func (f *FunctionCaller) Clear(mask Enum) {
+	asmClear(mask)
+}
+
+//go:noescape
+func asmClearColor(red float64, green float64, blue float64, alpha float64) 
+
+func (f *FunctionCaller) ClearColor(red, green, blue, alpha float32) {
+	asmClearColor(float64(red), float64(green), float64(blue), float64(alpha))
+}
+
+//go:noescape
+func asmClearDepthf(d float64) 
+
+func (f *FunctionCaller) ClearDepthf(d float32) {
+	asmClearDepthf(float64(d))
+}
+
+//go:noescape
+func asmCompileShader(s Shader) 
+
+func (f *FunctionCaller) CompileShader(s Shader) {
+	asmCompileShader(s)
+}
+
+//go:noescape
+func asmCopyTexSubImage2D(target Enum, level int, xoffset int, yoffset int, x int, y int, width int, height int) 
+
+func (f *FunctionCaller) CopyTexSubImage2D(target Enum, level, xoffset, yoffset, x, y, width, height int) {
+	asmCopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height)
+}
+
+//go:noescape
+func asmCreateBuffer() Buffer
+
+func (f *FunctionCaller) CreateBuffer() Buffer {
+	return asmCreateBuffer()
+}
+
+//go:noescape
+func asmCreateFramebuffer() Framebuffer
+
+func (f *FunctionCaller) CreateFramebuffer() Framebuffer {
+	return asmCreateFramebuffer()
+}
+
+//go:noescape
+func asmCreateProgram() Program
+
+func (f *FunctionCaller) CreateProgram() Program {
+	return asmCreateProgram()
+}
+
+//go:noescape
+func asmCreateRenderbuffer() Renderbuffer
+
+func (f *FunctionCaller) CreateRenderbuffer() Renderbuffer {
+	return asmCreateRenderbuffer()
+}
+
+//go:noescape
+func asmCreateShader(ty Enum) Shader
+
+func (f *FunctionCaller) CreateShader(ty Enum) Shader {
+	return asmCreateShader(ty)
+}
+
+//go:noescape
+func asmCreateTexture() Texture
+
+func (f *FunctionCaller) CreateTexture() Texture {
+	return asmCreateTexture()
+}
+
+//go:noescape
+func asmDeleteBuffer(v Buffer) 
+
+func (f *FunctionCaller) DeleteBuffer(v Buffer) {
+	asmDeleteBuffer(v)
+}
+
+//go:noescape
+func asmDeleteFramebuffer(v Framebuffer) 
+
+func (f *FunctionCaller) DeleteFramebuffer(v Framebuffer) {
+	asmDeleteFramebuffer(v)
+}
+
+//go:noescape
+func asmDeleteProgram(p Program) 
+
+func (f *FunctionCaller) DeleteProgram(p Program) {
+	asmDeleteProgram(p)
+}
+
+//go:noescape
+func asmDeleteShader(s Shader) 
+
+func (f *FunctionCaller) DeleteShader(s Shader) {
+	asmDeleteShader(s)
+}
+
+//go:noescape
+func asmDeleteRenderbuffer(v Renderbuffer) 
+
+func (f *FunctionCaller) DeleteRenderbuffer(v Renderbuffer) {
+	asmDeleteRenderbuffer(v)
+}
+
+//go:noescape
+func asmDeleteTexture(v Texture) 
+
+func (f *FunctionCaller) DeleteTexture(v Texture) {
+	asmDeleteTexture(v)
+}
+
+//go:noescape
+func asmDepthFunc(fn Enum) 
+
+func (f *FunctionCaller) DepthFunc(fn Enum) {
+	asmDepthFunc(fn)
+}
+
+//go:noescape
+func asmDepthMask(mask bool) 
+
+func (f *FunctionCaller) DepthMask(mask bool) {
+	asmDepthMask(mask)
+}
+
+//go:noescape
+func asmDisableVertexAttribArray(a Attrib) 
+
+func (f *FunctionCaller) DisableVertexAttribArray(a Attrib) {
+	asmDisableVertexAttribArray(a)
+}
+
+//go:noescape
+func asmDisable(cap Enum) 
+
+func (f *FunctionCaller) Disable(cap Enum) {
+	asmDisable(cap)
+}
+
+//go:noescape
+func asmDrawArrays(mode Enum, first int, count int) 
+
+func (f *FunctionCaller) DrawArrays(mode Enum, first, count int) {
+	asmDrawArrays(mode, first, count)
+}
+
+//go:noescape
+func asmDrawElements(mode Enum, count int, ty Enum, offset int) 
+
+func (f *FunctionCaller) DrawElements(mode Enum, count int, ty Enum, offset int) {
+	asmDrawElements(mode, count, ty, offset)
+}
+
+//go:noescape
+func asmEnable(cap Enum) 
+
+func (f *FunctionCaller) Enable(cap Enum) {
+	asmEnable(cap)
+}
+
+//go:noescape
+func asmEnableVertexAttribArray(a Attrib) 
+
+func (f *FunctionCaller) EnableVertexAttribArray(a Attrib) {
+	asmEnableVertexAttribArray(a)
+}
+
+//go:noescape
+func asmFinish() 
+
+func (f *FunctionCaller) Finish() {
+	asmFinish()
+}
+
+//go:noescape
+func asmFlush() 
+
+func (f *FunctionCaller) Flush() {
+	asmFlush()
+}
+
+//go:noescape
+func asmFramebufferRenderbuffer(target Enum, attachment Enum, renderbuffertarget Enum, renderbuffer Renderbuffer) 
+
+func (f *FunctionCaller) FramebufferRenderbuffer(target, attachment, renderbuffertarget Enum, renderbuffer Renderbuffer) {
+	asmFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer)
+}
+
+//go:noescape
+func asmFramebufferTexture2D(target Enum, attachment Enum, texTarget Enum, t Texture, level int) 
+
+func (f *FunctionCaller) FramebufferTexture2D(target, attachment, texTarget Enum, t Texture, level int) {
+	asmFramebufferTexture2D(target, attachment, texTarget, t, level)
+}
+
+//go:noescape
+func asmGetRenderbufferParameteri(pname Enum) int
+
+func (f *FunctionCaller) GetRenderbufferParameteri(target, pname Enum) int {
+	return asmGetRenderbufferParameteri(pname)
+}
+
+//go:noescape
+func asmGetFramebufferAttachmentParameteri(target Enum, attachment Enum, pname Enum) int
+
+func (f *FunctionCaller) GetFramebufferAttachmentParameteri(target, attachment, pname Enum) int {
+	return asmGetFramebufferAttachmentParameteri(target, attachment, pname)
+}
+
+//go:noescape
+func asmGetBinding(pname Enum) Object
+
+func (f *FunctionCaller) GetBinding(pname Enum) Object {
+	return asmGetBinding(pname)
+}
+
+//go:noescape
+func asmGetBindingi(pname Enum, idx int) Object
+
+func (f *FunctionCaller) GetBindingi(pname Enum, idx int) Object {
+	return asmGetBindingi(pname, idx)
+}
+
+//go:noescape
+func asmGetInteger(pname Enum) int
+
+func (f *FunctionCaller) GetInteger(pname Enum) int {
+	return asmGetInteger(pname)
+}
+
+//go:noescape
+func asmGetFloat(pname Enum) float32
+
+func (f *FunctionCaller) GetFloat(pname Enum) float32 {
+	return asmGetFloat(pname)
+}
+
+//go:noescape
+func asmGetInteger4(pname Enum) [4]int
+
+func (f *FunctionCaller) GetInteger4(pname Enum) [4]int {
+	return asmGetInteger4(pname)
+}
+
+//go:noescape
+func asmGetFloat4(pname Enum) [4]float32
+
+func (f *FunctionCaller) GetFloat4(pname Enum) [4]float32 {
+	return asmGetFloat4(pname)
+}
+
+//go:noescape
+func asmGetProgrami(p Program, pname Enum) int
+
+func (f *FunctionCaller) GetProgrami(p Program, pname Enum) int {
+	return asmGetProgrami(p, pname)
+}
+
+//go:noescape
+func asmGetShaderi(s Shader, pname Enum) int
+
+func (f *FunctionCaller) GetShaderi(s Shader, pname Enum) int {
+	return asmGetShaderi(s, pname)
+}
+
+//go:noescape
+func asmGetUniformBlockIndex(p Program, name string) uint
+
+func (f *FunctionCaller) GetUniformBlockIndex(p Program, name string) uint {
+	return asmGetUniformBlockIndex(p, name)
+}
+
+//go:noescape
+func asmGetUniformLocation(p Program, name string) Uniform
+
+func (f *FunctionCaller) GetUniformLocation(p Program, name string) Uniform {
+	return asmGetUniformLocation(p, name)
+}
+
+//go:noescape
+func asmGetVertexAttrib(index int, pname Enum) int
+
+func (f *FunctionCaller) GetVertexAttrib(index int, pname Enum) int {
+	return asmGetVertexAttrib(index, pname)
+}
+
+//go:noescape
+func asmGetVertexAttribBinding(index int, pname Enum) Object
+
+func (f *FunctionCaller) GetVertexAttribBinding(index int, pname Enum) Object {
+	return asmGetVertexAttribBinding(index, pname)
+}
+
+//go:noescape
+func asmGetVertexAttribPointer(index int, pname Enum) uintptr
+
+func (f *FunctionCaller) GetVertexAttribPointer(index int, pname Enum) uintptr {
+	return asmGetVertexAttribPointer(index, pname)
+}
+
+//go:noescape
+func asmInvalidateFramebuffer(target Enum, attachment Enum) 
+
+func (f *FunctionCaller) InvalidateFramebuffer(target, attachment Enum) {
+	asmInvalidateFramebuffer(target, attachment)
+}
+
+//go:noescape
+func asmIsEnabled(cap Enum) bool
+
+func (f *FunctionCaller) IsEnabled(cap Enum) bool {
+	return asmIsEnabled(cap)
+}
+
+//go:noescape
+func asmLinkProgram(p Program) 
+
+func (f *FunctionCaller) LinkProgram(p Program) {
+	asmLinkProgram(p)
+}
+
+//go:noescape
+func asmPixelStorei(pname Enum, param int) 
+
+func (f *FunctionCaller) PixelStorei(pname Enum, param int) {
+	asmPixelStorei(pname, param)
+}
+
+//go:noescape
+func asmRenderbufferStorage(target Enum, internalformat Enum, width int, height int) 
+
+func (f *FunctionCaller) RenderbufferStorage(target, internalformat Enum, width, height int) {
+	asmRenderbufferStorage(target, internalformat, width, height)
+}
+
+//go:noescape
+func asmReadPixels(x int, y int, width int, height int, format Enum, ty Enum, data []byte) 
+
+func (f *FunctionCaller) ReadPixels(x, y, width, height int, format, ty Enum, data []byte) {
+	asmReadPixels(x, y, width, height, format, ty, data)
+}
+
+//go:noescape
+func asmScissor(x int32, y int32, width int32, height int32) 
+
+func (f *FunctionCaller) Scissor(x, y, width, height int32) {
+	asmScissor(x, y, width, height)
+}
+
+//go:noescape
+func asmShaderSource(s Shader, src string) 
+
+func (f *FunctionCaller) ShaderSource(s Shader, src string) {
+	asmShaderSource(s, src)
+}
+
+//go:noescape
+func asmTexImage2D(target Enum, level int, internalFormat Enum, width int, height int, format Enum, ty Enum) 
+
+func (f *FunctionCaller) TexImage2D(target Enum, level int, internalFormat Enum, width, height int, format, ty Enum) {
+	asmTexImage2D(target, level, internalFormat, width, height, format, ty)
+}
+
+//go:noescape
+func asmTexStorage2D(target Enum, levels int, internalFormat Enum, width int, height int) 
+
+func (f *FunctionCaller) TexStorage2D(target Enum, levels int, internalFormat Enum, width, height int) {
+	asmTexStorage2D(target, levels, internalFormat, width, height)
+}
+
+//go:noescape
+func asmTexSubImage2D(target Enum, level int, x int, y int, width int, height int, format Enum, ty Enum, data []byte) 
+
+func (f *FunctionCaller) TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte) {
+	asmTexSubImage2D(target, level, x, y, width, height, format, ty, data)
+}
+
+//go:noescape
+func asmTexParameteri(target Enum, pname Enum, param int) 
+
+func (f *FunctionCaller) TexParameteri(target, pname Enum, param int) {
+	asmTexParameteri(target, pname, param)
+}
+
+//go:noescape
+func asmUniformBlockBinding(p Program, uniformBlockIndex uint, uniformBlockBinding uint) 
+
+func (f *FunctionCaller) UniformBlockBinding(p Program, uniformBlockIndex uint, uniformBlockBinding uint) {
+	asmUniformBlockBinding(p, uniformBlockIndex, uniformBlockBinding)
+}
+
+//go:noescape
+func asmUniform1f(dst Uniform, v float64) 
+
+func (f *FunctionCaller) Uniform1f(dst Uniform, v float32) {
+	asmUniform1f(dst, float64(v))
+}
+
+//go:noescape
+func asmUniform1i(dst Uniform, v int) 
+
+func (f *FunctionCaller) Uniform1i(dst Uniform, v int) {
+	asmUniform1i(dst, v)
+}
+
+//go:noescape
+func asmUniform2f(dst Uniform, v0 float64, v1 float64) 
+
+func (f *FunctionCaller) Uniform2f(dst Uniform, v0, v1 float32) {
+	asmUniform2f(dst, float64(v0), float64(v1))
+}
+
+//go:noescape
+func asmUniform3f(dst Uniform, v0 float64, v1 float64, v2 float64) 
+
+func (f *FunctionCaller) Uniform3f(dst Uniform, v0, v1, v2 float32) {
+	asmUniform3f(dst, float64(v0), float64(v1), float64(v2))
+}
+
+//go:noescape
+func asmUniform4f(dst Uniform, v0 float64, v1 float64, v2 float64, v3 float64) 
+
+func (f *FunctionCaller) Uniform4f(dst Uniform, v0, v1, v2, v3 float32) {
+	asmUniform4f(dst, float64(v0), float64(v1), float64(v2), float64(v3))
+}
+
+//go:noescape
+func asmUseProgram(p Program) 
+
+func (f *FunctionCaller) UseProgram(p Program) {
+	asmUseProgram(p)
+}
+
+//go:noescape
+func asmVertexAttribPointer(dst Attrib, size int, ty Enum, normalized bool, stride int, offset int) 
+
+func (f *FunctionCaller) VertexAttribPointer(dst Attrib, size int, ty Enum, normalized bool, stride, offset int) {
+	asmVertexAttribPointer(dst, size, ty, normalized, stride, offset)
+}
+
+//go:noescape
+func asmViewport(x int, y int, width int, height int) 
+
+func (f *FunctionCaller) Viewport(x, y, width, height int) {
+	asmViewport(x, y, width, height)
+}

--- a/internal/gl/gl_unsafe_js.js
+++ b/internal/gl/gl_unsafe_js.js
@@ -1,0 +1,981 @@
+(() => {
+
+    // webgl is the array which handles the WebGL context. See InitGL function.
+    let webgl = 0;
+
+    // textDecoder holds the TextDecoder used for encode string.
+    let textDecoder = new TextDecoder("utf-8");
+
+    // invalidateBuffer is re-use when you call invalidateBuffer().
+    let invalidateBuffer = new Int32Array(1);
+
+    // hold values from JS
+    let values = [undefined]
+    let valuesPool = []
+
+    // Offset* is the byte-size of each type (matches with Reflect.Sizeof()).
+    const OffsetContextIndex = 8;
+    const OffsetInt64 = 8;
+    const OffsetFloat64 = 8;
+    const OffsetJSValue = 8;
+    const OffsetString = 16;
+    const OffsetSlice = 24;
+
+	globalThis.setUnsafeGL = (gl) => {
+        webgl = gl
+    }
+
+    const gioLoadBool = (addr) => {
+        return gioLoadInt64(addr) > 0
+    }
+    const gioLoadInt64 = (addr) => {
+        return go.mem.getUint32(addr + 8, true) + go.mem.getInt32(addr + 12, true) * 4294967296;
+    }
+    const gioLoadInt32 = (addr) => {
+        return go.mem.getUint32(addr + 8, true);
+    }
+    const gioLoadObject = (addr) => {
+        return values[gioLoadInt64(addr)];
+    }
+    const gioLoadString = (addr) => {
+        return textDecoder.decode(new DataView(go._inst.exports.mem.buffer, gioLoadInt64(addr), gioLoadInt64(addr + 8)));
+    }
+    const gioLoadSlice = (addr) => {
+        const s = new Uint8Array(go._inst.exports.mem.buffer, gioLoadInt64(addr), gioLoadInt64(addr + 8))
+        if (s.byteLength === 0) {
+            return null
+        }
+        return s
+    }
+    const gioLoadFloat64 = (addr) => {
+        return go.mem.getFloat64(addr + 8, true);
+    }
+    const gioLoadFloat32 = (addr) => {
+        return go.mem.getFloat32(addr + 4, true);
+    }
+
+    const gioSetObject = (addr, v) => {
+        let id = 0;
+        if (v !== undefined && v !== null && v !== false) {
+            id = valuesPool.pop();
+            if (id !== undefined) {
+                values[id] = v;
+            } else {
+                id = values.push(v) - 1;
+            }
+        }
+
+        gioSetInt64(addr, id)
+    }
+    const gioSetInt64 = (addr, v) => {
+		if (v === true) {
+			v = 1;
+		}
+        go.mem.setUint32(addr + 8 + 4, 0, true);
+        go.mem.setUint32(addr + 8, v, true);
+    }
+    const gioSetArray4 = (addr, r) => {
+        for (let i = 0; i < r.length; i++) {
+            gioSetInt64(addr, r[i])
+            addr += 8
+        }
+    }
+
+	const gioDeleteObject = (addr) => {
+		valuesPool.push(gioLoadInt64(addr));
+	}
+
+    Object.assign(go.importObject.go, {
+         // (f *FunctionCaller) ActiveTexture(t Enum)
+		 "gioui.org/internal/gl.asmActiveTexture": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.activeTexture(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) AttachShader(p Program, s Shader)
+		 "gioui.org/internal/gl.asmAttachShader": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.attachShader(
+				gioLoadObject((sp)+0),
+				gioLoadObject((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindAttribLocation(p Program, a Attrib, name string)
+		 "gioui.org/internal/gl.asmBindAttribLocation": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindAttribLocation(
+				gioLoadObject((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadString((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindBuffer(target Enum, b Buffer)
+		 "gioui.org/internal/gl.asmBindBuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindBuffer(
+				gioLoadInt64((sp)+0),
+				gioLoadObject((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindBufferBase(target Enum, index int, b Buffer)
+		 "gioui.org/internal/gl.asmBindBufferBase": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindBufferBase(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadObject((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindFramebuffer(target Enum, fb Framebuffer)
+		 "gioui.org/internal/gl.asmBindFramebuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindFramebuffer(
+				gioLoadInt64((sp)+0),
+				gioLoadObject((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindRenderbuffer(target Enum, rb Renderbuffer)
+		 "gioui.org/internal/gl.asmBindRenderbuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindRenderbuffer(
+				gioLoadInt64((sp)+0),
+				gioLoadObject((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BindTexture(target Enum, t Texture)
+		 "gioui.org/internal/gl.asmBindTexture": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bindTexture(
+				gioLoadInt64((sp)+0),
+				gioLoadObject((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BlendEquation(mode Enum)
+		 "gioui.org/internal/gl.asmBlendEquation": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.blendEquation(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BlendFuncSeparate(srcRGB, dstRGB, srcA, dstA Enum)
+		 "gioui.org/internal/gl.asmBlendFuncSeparate": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.blendFunc(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BufferData(target Enum, usage Enum, data []byte)
+		 "gioui.org/internal/gl.asmBufferData": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bufferData(
+				gioLoadInt64((sp)+0),
+				gioLoadSlice((sp)+0+8),
+				gioLoadInt64((sp)+0+8+24),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BufferDataSize(target Enum, size int, usage Enum)
+		 "gioui.org/internal/gl.asmBufferDataSize": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bufferData(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) BufferSubData(target Enum, offset int, src []byte)
+		 "gioui.org/internal/gl.asmBufferSubData": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.bufferSubData(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadSlice((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) CheckFramebufferStatus(target Enum) Enum
+		 "gioui.org/internal/gl.asmCheckFramebufferStatus": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.checkFramebufferStatus(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) Clear(mask Enum)
+		 "gioui.org/internal/gl.asmClear": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.clear(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) ClearColor(red, green, blue, alpha float32)
+		 "gioui.org/internal/gl.asmClearColor": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.clearColor(
+				gioLoadFloat64((sp)+0),
+				gioLoadFloat64((sp)+0+8),
+				gioLoadFloat64((sp)+0+8+8),
+				gioLoadFloat64((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) ClearDepthf(d float32)
+		 "gioui.org/internal/gl.asmClearDepthf": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.clearDepth(
+				gioLoadFloat64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) CompileShader(s Shader)
+		 "gioui.org/internal/gl.asmCompileShader": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.compileShader(
+				gioLoadObject((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) CopyTexSubImage2D(target Enum, level, xoffset, yoffset, x, y, width, height int)
+		 "gioui.org/internal/gl.asmCopyTexSubImage2D": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.copyTexSubImage2D(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) CreateBuffer() Buffer
+		 "gioui.org/internal/gl.asmCreateBuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createBuffer(
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0, r)
+        },
+         // (f *FunctionCaller) CreateFramebuffer() Framebuffer
+		 "gioui.org/internal/gl.asmCreateFramebuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createFramebuffer(
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0, r)
+        },
+         // (f *FunctionCaller) CreateProgram() Program
+		 "gioui.org/internal/gl.asmCreateProgram": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createProgram(
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0, r)
+        },
+         // (f *FunctionCaller) CreateRenderbuffer() Renderbuffer
+		 "gioui.org/internal/gl.asmCreateRenderbuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createRenderbuffer(
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0, r)
+        },
+         // (f *FunctionCaller) CreateShader(ty Enum) Shader
+		 "gioui.org/internal/gl.asmCreateShader": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createShader(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) CreateTexture() Texture
+		 "gioui.org/internal/gl.asmCreateTexture": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.createTexture(
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0, r)
+        },
+         // (f *FunctionCaller) DeleteBuffer(v Buffer)
+		 "gioui.org/internal/gl.asmDeleteBuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteBuffer(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DeleteFramebuffer(v Framebuffer)
+		 "gioui.org/internal/gl.asmDeleteFramebuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteFramebuffer(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DeleteProgram(p Program)
+		 "gioui.org/internal/gl.asmDeleteProgram": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteProgram(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DeleteShader(s Shader)
+		 "gioui.org/internal/gl.asmDeleteShader": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteShader(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DeleteRenderbuffer(v Renderbuffer)
+		 "gioui.org/internal/gl.asmDeleteRenderbuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteRenderbuffer(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DeleteTexture(v Texture)
+		 "gioui.org/internal/gl.asmDeleteTexture": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.deleteTexture(
+				gioLoadObject((sp)+0),
+			);
+
+            gioDeleteObject(sp)
+        },
+         // (f *FunctionCaller) DepthFunc(fn Enum)
+		 "gioui.org/internal/gl.asmDepthFunc": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.depthFunc(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) DepthMask(mask bool)
+		 "gioui.org/internal/gl.asmDepthMask": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.depthMask(
+				gioLoadBool((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) DisableVertexAttribArray(a Attrib)
+		 "gioui.org/internal/gl.asmDisableVertexAttribArray": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.disableVertexAttribArray(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Disable(cap Enum)
+		 "gioui.org/internal/gl.asmDisable": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.disable(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) DrawArrays(mode Enum, first, count int)
+		 "gioui.org/internal/gl.asmDrawArrays": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.drawArrays(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) DrawElements(mode Enum, count int, ty Enum, offset int)
+		 "gioui.org/internal/gl.asmDrawElements": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.drawElements(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Enable(cap Enum)
+		 "gioui.org/internal/gl.asmEnable": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.enable(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) EnableVertexAttribArray(a Attrib)
+		 "gioui.org/internal/gl.asmEnableVertexAttribArray": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.enableVertexAttribArray(
+				gioLoadInt64((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Finish()
+		 "gioui.org/internal/gl.asmFinish": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.finish(
+			);
+
+            
+        },
+         // (f *FunctionCaller) Flush()
+		 "gioui.org/internal/gl.asmFlush": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.flush(
+			);
+
+            
+        },
+         // (f *FunctionCaller) FramebufferRenderbuffer(target, attachment, renderbuffertarget Enum, renderbuffer Renderbuffer)
+		 "gioui.org/internal/gl.asmFramebufferRenderbuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.framebufferRenderbuffer(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadObject((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) FramebufferTexture2D(target, attachment, texTarget Enum, t Texture, level int)
+		 "gioui.org/internal/gl.asmFramebufferTexture2D": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.framebufferTexture2D(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadObject((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) GetRenderbufferParameteri(target, pname Enum) int
+		 "gioui.org/internal/gl.asmGetRenderbufferParameteri": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getRenderbufferParameteri(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetFramebufferAttachmentParameteri(target, attachment, pname Enum) int
+		 "gioui.org/internal/gl.asmGetFramebufferAttachmentParameteri": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getFramebufferAttachmentParameter(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+8+8, r)
+        },
+         // (f *FunctionCaller) GetBinding(pname Enum) Object
+		 "gioui.org/internal/gl.asmGetBinding": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getParameter(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetBindingi(pname Enum, idx int) Object
+		 "gioui.org/internal/gl.asmGetBindingi": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getIndexedParameter(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) GetInteger(pname Enum) int
+		 "gioui.org/internal/gl.asmGetInteger": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getParameter(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetFloat(pname Enum) float32
+		 "gioui.org/internal/gl.asmGetFloat": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getParameter(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetInteger4(pname Enum) [4]int
+		 "gioui.org/internal/gl.asmGetInteger4": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getParameter(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetArray4((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetFloat4(pname Enum) [4]float32
+		 "gioui.org/internal/gl.asmGetFloat4": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getParameter(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetArray4((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) GetProgrami(p Program, pname Enum) int
+		 "gioui.org/internal/gl.asmGetProgrami": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getProgramParameter(
+				gioLoadObject((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) GetShaderi(s Shader, pname Enum) int
+		 "gioui.org/internal/gl.asmGetShaderi": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getShaderParameter(
+				gioLoadObject((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) GetUniformBlockIndex(p Program, name string) uint
+		 "gioui.org/internal/gl.asmGetUniformBlockIndex": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getUniformBlockIndex(
+				gioLoadObject((sp)+0),
+				gioLoadString((sp)+0+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+16, r)
+        },
+         // (f *FunctionCaller) GetUniformLocation(p Program, name string) Uniform
+		 "gioui.org/internal/gl.asmGetUniformLocation": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getUniformLocation(
+				gioLoadObject((sp)+0),
+				gioLoadString((sp)+0+8),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8+16, r)
+        },
+         // (f *FunctionCaller) GetVertexAttrib(index int, pname Enum) int
+		 "gioui.org/internal/gl.asmGetVertexAttrib": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getVertexAttrib(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) GetVertexAttribBinding(index int, pname Enum) Object
+		 "gioui.org/internal/gl.asmGetVertexAttribBinding": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getVertexAttrib(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetObject((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) GetVertexAttribPointer(index int, pname Enum) uintptr
+		 "gioui.org/internal/gl.asmGetVertexAttribPointer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.getVertexAttribOffset(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8+8, r)
+        },
+         // (f *FunctionCaller) InvalidateFramebuffer(target, attachment Enum)
+		 "gioui.org/internal/gl.asmInvalidateFramebuffer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.invalidateFramebuffer(
+				gioLoadInt64((sp)+0),
+				[gioLoadInt64(sp+0+8)],
+			);
+
+            
+        },
+         // (f *FunctionCaller) IsEnabled(cap Enum) bool
+		 "gioui.org/internal/gl.asmIsEnabled": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.isEnabled(
+				gioLoadInt64((sp)+0),
+			);
+
+            gioSetInt64((go._inst.exports.getsp() >>> 0)+0+8, r)
+        },
+         // (f *FunctionCaller) LinkProgram(p Program)
+		 "gioui.org/internal/gl.asmLinkProgram": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.linkProgram(
+				gioLoadObject((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) PixelStorei(pname Enum, param int)
+		 "gioui.org/internal/gl.asmPixelStorei": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.pixelStorei(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) RenderbufferStorage(target, internalformat Enum, width, height int)
+		 "gioui.org/internal/gl.asmRenderbufferStorage": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.renderbufferStorage(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) ReadPixels(x, y, width, height int, format, ty Enum, data []byte)
+		 "gioui.org/internal/gl.asmReadPixels": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.readPixels(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8),
+				gioLoadSlice((sp)+0+8+8+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Scissor(x, y, width, height int32)
+		 "gioui.org/internal/gl.asmScissor": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.scissor(
+				gioLoadInt32((sp)+0),
+				gioLoadInt32((sp)+0+8),
+				gioLoadInt32((sp)+0+8+8),
+				gioLoadInt32((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) ShaderSource(s Shader, src string)
+		 "gioui.org/internal/gl.asmShaderSource": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.shaderSource(
+				gioLoadObject((sp)+0),
+				gioLoadString((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) TexImage2D(target Enum, level int, internalFormat Enum, width, height int, format, ty Enum)
+		 "gioui.org/internal/gl.asmTexImage2D": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.texImage2D(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+				0,
+				gioLoadInt64((sp)+0+8+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8+8),
+				undefined,
+			);
+
+            
+        },
+         // (f *FunctionCaller) TexStorage2D(target Enum, levels int, internalFormat Enum, width, height int)
+		 "gioui.org/internal/gl.asmTexStorage2D": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.texStorage2D(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) TexSubImage2D(target Enum, level int, x, y, width, height int, format, ty Enum, data []byte)
+		 "gioui.org/internal/gl.asmTexSubImage2D": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.texSubImage2D(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8+8+8),
+				gioLoadSlice((sp)+0+8+8+8+8+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) TexParameteri(target, pname Enum, param int)
+		 "gioui.org/internal/gl.asmTexParameteri": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.texParameteri(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) UniformBlockBinding(p Program, uniformBlockIndex uint, uniformBlockBinding uint)
+		 "gioui.org/internal/gl.asmUniformBlockBinding": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniformBlockBinding(
+				gioLoadObject((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Uniform1f(dst Uniform, v float32)
+		 "gioui.org/internal/gl.asmUniform1f": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniform1f(
+				gioLoadObject((sp)+0),
+				gioLoadFloat64((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Uniform1i(dst Uniform, v int)
+		 "gioui.org/internal/gl.asmUniform1i": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniform1i(
+				gioLoadObject((sp)+0),
+				gioLoadInt64((sp)+0+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Uniform2f(dst Uniform, v0, v1 float32)
+		 "gioui.org/internal/gl.asmUniform2f": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniform2f(
+				gioLoadObject((sp)+0),
+				gioLoadFloat64((sp)+0+8),
+				gioLoadFloat64((sp)+0+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Uniform3f(dst Uniform, v0, v1, v2 float32)
+		 "gioui.org/internal/gl.asmUniform3f": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniform3f(
+				gioLoadObject((sp)+0),
+				gioLoadFloat64((sp)+0+8),
+				gioLoadFloat64((sp)+0+8+8),
+				gioLoadFloat64((sp)+0+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Uniform4f(dst Uniform, v0, v1, v2, v3 float32)
+		 "gioui.org/internal/gl.asmUniform4f": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.uniform4f(
+				gioLoadObject((sp)+0),
+				gioLoadFloat64((sp)+0+8),
+				gioLoadFloat64((sp)+0+8+8),
+				gioLoadFloat64((sp)+0+8+8+8),
+				gioLoadFloat64((sp)+0+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) UseProgram(p Program)
+		 "gioui.org/internal/gl.asmUseProgram": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.useProgram(
+				gioLoadObject((sp)+0),
+			);
+
+            
+        },
+         // (f *FunctionCaller) VertexAttribPointer(dst Attrib, size int, ty Enum, normalized bool, stride, offset int)
+		 "gioui.org/internal/gl.asmVertexAttribPointer": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.vertexAttribPointer(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadBool((sp)+0+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8),
+				gioLoadInt64((sp)+0+8+8+8+8+8),
+			);
+
+            
+        },
+         // (f *FunctionCaller) Viewport(x, y, width, height int)
+		 "gioui.org/internal/gl.asmViewport": (sp) => {
+            sp = (sp >>> 0);
+
+            let r = webgl.viewport(
+				gioLoadInt64((sp)+0),
+				gioLoadInt64((sp)+0+8),
+				gioLoadInt64((sp)+0+8+8),
+				gioLoadInt64((sp)+0+8+8+8),
+			);
+
+            
+        },
+	})
+})();

--- a/internal/gl/gl_unsafe_js.s
+++ b/internal/gl/gl_unsafe_js.s
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Unlicense OR MIT
+
+#include "textflag.h"
+
+TEXT ·asmActiveTexture(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmAttachShader(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindAttribLocation(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindBuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindBufferBase(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindFramebuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindRenderbuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBindTexture(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBlendEquation(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBlendFuncSeparate(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBufferData(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBufferDataSize(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmBufferSubData(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCheckFramebufferStatus(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmClear(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmClearColor(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmClearDepthf(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCompileShader(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCopyTexSubImage2D(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateBuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateFramebuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateProgram(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateRenderbuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateShader(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmCreateTexture(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteBuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteFramebuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteProgram(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteShader(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteRenderbuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDeleteTexture(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDepthFunc(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDepthMask(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDisableVertexAttribArray(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDisable(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDrawArrays(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmDrawElements(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmEnable(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmEnableVertexAttribArray(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmFinish(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmFlush(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmFramebufferRenderbuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmFramebufferTexture2D(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetRenderbufferParameteri(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetFramebufferAttachmentParameteri(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetBinding(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetBindingi(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetInteger(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetFloat(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetInteger4(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetFloat4(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetProgrami(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetShaderi(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetUniformBlockIndex(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetUniformLocation(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetVertexAttrib(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetVertexAttribBinding(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmGetVertexAttribPointer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmInvalidateFramebuffer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmIsEnabled(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmLinkProgram(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmPixelStorei(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmRenderbufferStorage(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmReadPixels(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmScissor(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmShaderSource(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmTexImage2D(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmTexStorage2D(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmTexSubImage2D(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmTexParameteri(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniformBlockBinding(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniform1f(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniform1i(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniform2f(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniform3f(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUniform4f(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmUseProgram(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmVertexAttribPointer(SB), NOSPLIT, $0
+  CallImport
+  RET
+
+TEXT ·asmViewport(SB), NOSPLIT, $0
+  CallImport
+  RET
+

--- a/internal/gl/types_syscall_js.go
+++ b/internal/gl/types_syscall_js.go
@@ -1,0 +1,92 @@
+//go:build !unsafe
+// +build !unsafe
+
+// SPDX-License-Identifier: Unlicense OR MIT
+
+package gl
+
+import "syscall/js"
+
+type (
+	Object       js.Value
+	Buffer       Object
+	Framebuffer  Object
+	Program      Object
+	Renderbuffer Object
+	Shader       Object
+	Texture      Object
+	Uniform      Object
+	VertexArray  Object
+)
+
+func (o Object) valid() bool {
+	return js.Value(o).Truthy()
+}
+
+func (o Object) equal(o2 Object) bool {
+	return js.Value(o).Equal(js.Value(o2))
+}
+
+func (b Buffer) Valid() bool {
+	return Object(b).valid()
+}
+
+func (f Framebuffer) Valid() bool {
+	return Object(f).valid()
+}
+
+func (p Program) Valid() bool {
+	return Object(p).valid()
+}
+
+func (r Renderbuffer) Valid() bool {
+	return Object(r).valid()
+}
+
+func (s Shader) Valid() bool {
+	return Object(s).valid()
+}
+
+func (t Texture) Valid() bool {
+	return Object(t).valid()
+}
+
+func (u Uniform) Valid() bool {
+	return Object(u).valid()
+}
+
+func (a VertexArray) Valid() bool {
+	return Object(a).valid()
+}
+
+func (f Framebuffer) Equal(f2 Framebuffer) bool {
+	return Object(f).equal(Object(f2))
+}
+
+func (p Program) Equal(p2 Program) bool {
+	return Object(p).equal(Object(p2))
+}
+
+func (s Shader) Equal(s2 Shader) bool {
+	return Object(s).equal(Object(s2))
+}
+
+func (u Uniform) Equal(u2 Uniform) bool {
+	return Object(u).equal(Object(u2))
+}
+
+func (a VertexArray) Equal(a2 VertexArray) bool {
+	return Object(a).equal(Object(a2))
+}
+
+func (r Renderbuffer) Equal(r2 Renderbuffer) bool {
+	return Object(r).equal(Object(r2))
+}
+
+func (t Texture) Equal(t2 Texture) bool {
+	return Object(t).equal(Object(t2))
+}
+
+func (b Buffer) Equal(b2 Buffer) bool {
+	return Object(b).equal(Object(b2))
+}

--- a/internal/gl/types_unsafe_js.go
+++ b/internal/gl/types_unsafe_js.go
@@ -1,28 +1,30 @@
+//go:build unsafe
+// +build unsafe
+
 // SPDX-License-Identifier: Unlicense OR MIT
 
 package gl
 
-import "syscall/js"
-
 type (
-	Object       js.Value
+	Object struct {
+		ref int64
+	}
 	Buffer       Object
 	Framebuffer  Object
 	Program      Object
 	Renderbuffer Object
 	Shader       Object
 	Texture      Object
-	Query        Object
 	Uniform      Object
 	VertexArray  Object
 )
 
 func (o Object) valid() bool {
-	return js.Value(o).Truthy()
+	return o.ref != 0
 }
 
 func (o Object) equal(o2 Object) bool {
-	return js.Value(o).Equal(js.Value(o2))
+	return o.ref == o2.ref
 }
 
 func (b Buffer) Valid() bool {


### PR DESCRIPTION
That change avoid JS calls through `syscall/js`. Instead we use the
WebAssembly imports, which is defined on the `gl_js.s` and `gl_js.js`.

That change is similar to the previous patch, but it's easier to read
the code and fix. It also have only five JavaScript functions, instead
of one function for each WebGL call.

Opera 72 (w/ AMD Ryzen 3900X): ~8.0ms per frame to ~3.4ms;
Chrome 87 (w/ Snapdragon 435): ~83.2ms per frame to ~39.8ms;

The `gl_js.js` file is embed by the `gogio` compiler.

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>