### PR TITLE
app, app/internal: [wasm,android] add navigation/status color changer

### DIFF
--- a/app/internal/wm/window.go
+++ b/app/internal/wm/window.go
@@ -6,6 +6,7 @@ package wm
 
 import (
 	"errors"
+	"image/color"
 
 	"gioui.org/gpu"
 	"gioui.org/io/event"
@@ -20,11 +21,13 @@ type Size struct {
 }
 
 type Options struct {
-	Size       *Size
-	MinSize    *Size
-	MaxSize    *Size
-	Title      *string
-	WindowMode *WindowMode
+	Size            *Size
+	MinSize         *Size
+	MaxSize         *Size
+	Title           *string
+	WindowMode      *WindowMode
+	StatusColor     *color.NRGBA
+	NavigationColor *color.NRGBA
 }
 
 type WindowMode uint8

--- a/app/window.go
+++ b/app/window.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"image/color"
 	"time"
 
 	"gioui.org/io/event"
@@ -522,6 +523,20 @@ func MinSize(w, h unit.Value) Option {
 			Width:  w,
 			Height: h,
 		}
+	}
+}
+
+// StatusColor sets the color of the Android status bar.
+func StatusColor(color color.NRGBA) Option {
+	return func(opts *wm.Options) {
+		opts.StatusColor = &color
+	}
+}
+
+// NavigationColor sets the color of the navigation bar on Android, or the address bar in browsers.
+func NavigationColor(color color.NRGBA) Option {
+	return func(opts *wm.Options) {
+		opts.NavigationColor = &color
 	}
 }
 


### PR DESCRIPTION
This changes adds the `window.SetColor` to programmatically change the color
of the Status-Bar and Navigation-Bar on Android and WASM (supported by Chrome
on Android).

Note: Windows, Linux, MacOS, iOS, FreeBSD, OpenBSD remains unchanged and
will be ignored.