### PR TITLE
app, app/internal/window: add window.SetOptions for Options changes.

### DIFF
--- a/app/internal/window/os_android.go
+++ b/app/internal/window/os_android.go
@@ -651,7 +651,7 @@ func goString(env *C.JNIEnv, str C.jstring) string {
 func Main() {
 }
 
-func NewWindow(window Callbacks, opts *Options) error {
+func NewWindow(window Callbacks, opts *Option) error {
 	mainWindow.in <- windowAndOptions{window, opts}
 	return <-mainWindow.errs
 }
@@ -680,6 +680,10 @@ func (w *window) SetCursor(name pointer.CursorName) {
 	w.setState(func(state *windowState) {
 		state.cursor = &name
 	})
+}
+
+func (w *window) SetOption(option Option) {
+	// Not supported on Android.
 }
 
 // setState adjust the window state on the main thread.

--- a/app/internal/window/os_ios.go
+++ b/app/internal/window/os_ios.go
@@ -255,6 +255,10 @@ func (w *window) SetCursor(name pointer.CursorName) {
 	w.cursor = windowSetCursor(w.cursor, name)
 }
 
+func (w *window) SetOption(option Option) {
+	// Not implemented for iOS
+}
+
 func (w *window) onKeyCommand(name string) {
 	w.w.Event(key.Event{
 		Name: name,
@@ -308,7 +312,7 @@ func (w *window) ShowTextInput(show bool) {
 // Close the window. Not implemented for iOS.
 func (w *window) Close() {}
 
-func NewWindow(win Callbacks, opts *Options) error {
+func NewWindow(win Callbacks, opts *Option) error {
 	mainWindow.in <- windowAndOptions{win, opts}
 	return <-mainWindow.errs
 }

--- a/app/internal/window/os_js.go
+++ b/app/internal/window/os_js.go
@@ -46,7 +46,7 @@ type window struct {
 	animRequested bool
 }
 
-func NewWindow(win Callbacks, opts *Options) error {
+func NewWindow(win Callbacks, opts *Option) error {
 	doc := js.Global().Get("document")
 	cont := getContainer(doc)
 	cnv := createCanvas(doc)
@@ -463,6 +463,10 @@ func (w *window) WriteClipboard(s string) {
 func (w *window) SetCursor(name pointer.CursorName) {
 	style := w.cnv.Get("style")
 	style.Set("cursor", string(name))
+}
+
+func (w *window) SetOption(option Option) {
+	// Not supported on JS.
 }
 
 func (w *window) ShowTextInput(show bool) {

--- a/app/internal/window/os_unix.go
+++ b/app/internal/window/os_unix.go
@@ -12,13 +12,13 @@ func Main() {
 	select {}
 }
 
-type windowDriver func(Callbacks, *Options) error
+type windowDriver func(Callbacks, *Option) error
 
 // Instead of creating files with build tags for each combination of wayland +/- x11
 // let each driver initialize these variables with their own version of createWindow.
 var wlDriver, x11Driver windowDriver
 
-func NewWindow(window Callbacks, opts *Options) error {
+func NewWindow(window Callbacks, opts *Option) error {
 	var errFirst error
 	for _, d := range []windowDriver{x11Driver, wlDriver} {
 		if d == nil {

--- a/app/internal/window/os_wayland.go
+++ b/app/internal/window/os_wayland.go
@@ -224,7 +224,7 @@ func init() {
 	wlDriver = newWLWindow
 }
 
-func newWLWindow(window Callbacks, opts *Options) error {
+func newWLWindow(window Callbacks, opts *Option) error {
 	d, err := newWLDisplay()
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func (d *wlDisplay) readClipboard() (io.ReadCloser, error) {
 	return r, nil
 }
 
-func (d *wlDisplay) createNativeWindow(opts *Options) (*window, error) {
+func (d *wlDisplay) createNativeWindow(opts *Option) (*window, error) {
 	if d.compositor == nil {
 		return nil, errors.New("wayland: no compositor available")
 	}
@@ -353,13 +353,13 @@ func (d *wlDisplay) createNativeWindow(opts *Options) (*window, error) {
 	C.wl_surface_add_listener(w.surf, &C.gio_surface_listener, unsafe.Pointer(w.surf))
 	C.xdg_surface_add_listener(w.wmSurf, &C.gio_xdg_surface_listener, unsafe.Pointer(w.surf))
 	C.xdg_toplevel_add_listener(w.topLvl, &C.gio_xdg_toplevel_listener, unsafe.Pointer(w.surf))
-	title := C.CString(opts.Title)
+	title := C.CString(*opts.Title)
 	C.xdg_toplevel_set_title(w.topLvl, title)
 	C.free(unsafe.Pointer(title))
 
 	_, _, cfg := w.config()
-	w.width = cfg.Px(opts.Width)
-	w.height = cfg.Px(opts.Height)
+	w.width = cfg.Px(*opts.Width)
+	w.height = cfg.Px(*opts.Height)
 	if d.decor != nil {
 		// Request server side decorations.
 		w.decor = C.zxdg_decoration_manager_v1_get_toplevel_decoration(d.decor, w.topLvl)
@@ -952,6 +952,10 @@ func (w *window) setCursor(pointer *C.struct_wl_pointer, serial C.uint32_t) {
 	C.wl_surface_attach(w.cursor.surf, buf, 0, 0)
 	C.wl_surface_damage(w.cursor.surf, 0, 0, C.int32_t(img.width), C.int32_t(img.height))
 	C.wl_surface_commit(w.cursor.surf)
+}
+
+func (w *window) SetOption(option Option) {
+	// Not supported on Wayland.
 }
 
 func (w *window) resetFling() {

--- a/app/internal/window/window.go
+++ b/app/internal/window/window.go
@@ -14,13 +14,12 @@ import (
 	"gioui.org/unit"
 )
 
-type Options struct {
-	Width, Height       unit.Value
-	MinWidth, MinHeight unit.Value
-	MaxWidth, MaxHeight unit.Value
-	Title               string
+type Option struct {
+	Width, Height       *unit.Value
+	MinWidth, MinHeight *unit.Value
+	MaxWidth, MaxHeight *unit.Value
+	Title               *string
 }
-
 type FrameEvent struct {
 	system.FrameEvent
 
@@ -64,6 +63,9 @@ type Driver interface {
 	// SetCursor updates the current cursor to name.
 	SetCursor(name pointer.CursorName)
 
+	// SetOption updates the current window Option.
+	SetOption(option Option)
+
 	// Close the window.
 	Close()
 }
@@ -76,7 +78,7 @@ type windowRendezvous struct {
 
 type windowAndOptions struct {
 	window Callbacks
-	opts   *Options
+	opts   *Option
 }
 
 func newWindowRendezvous() *windowRendezvous {

--- a/app/internal/windows/windows.go
+++ b/app/internal/windows/windows.go
@@ -210,6 +210,22 @@ const (
 	LR_MONOCHROME       = 0x00000001
 	LR_SHARED           = 0x00008000
 	LR_VGACOLOR         = 0x00000080
+
+	SWP_ASYNCWINDOWPOS = 0x4000
+	SWP_DEFERERASE     = 0x2000
+	SWP_DRAWFRAME      = 0x0020
+	SWP_FRAMECHANGED   = 0x0020
+	SWP_HIDEWINDOW     = 0x0080
+	SWP_NOACTIVATE     = 0x0010
+	SWP_NOCOPYBITS     = 0x0100
+	SWP_NOMOVE         = 0x0002
+	SWP_NOOWNERZORDER  = 0x0200
+	SWP_NOREDRAW       = 0x0008
+	SWP_NOREPOSITION   = 0x0200
+	SWP_NOSENDCHANGING = 0x0400
+	SWP_NOSIZE         = 0x0001
+	SWP_NOZORDER       = 0x0004
+	SWP_SHOWWINDOW     = 0x0040
 )
 
 var (
@@ -257,6 +273,8 @@ var (
 	_SetFocus                    = user32.NewProc("SetFocus")
 	_SetProcessDPIAware          = user32.NewProc("SetProcessDPIAware")
 	_SetTimer                    = user32.NewProc("SetTimer")
+	_SetWindowPos                = user32.NewProc("SetWindowPos")
+	_SetWindowText               = user32.NewProc("SetWindowTextW")
 	_TranslateMessage            = user32.NewProc("TranslateMessage")
 	_UnregisterClass             = user32.NewProc("UnregisterClassW")
 	_UpdateWindow                = user32.NewProc("UpdateWindow")
@@ -557,6 +575,16 @@ func SetTimer(hwnd syscall.Handle, nIDEvent uintptr, uElapse uint32, timerProc u
 		return fmt.Errorf("SetTimer failed: %v", err)
 	}
 	return nil
+}
+
+func SetWindowPos(hwnd syscall.Handle, hwndafter syscall.Handle, x, y int32, cx, cy int32, flags uint32) error {
+	_, _, err := _SetWindowPos.Call(uintptr(hwnd), uintptr(hwndafter), uintptr(x), uintptr(y), uintptr(cx), uintptr(cy), uintptr(flags))
+	return err
+}
+
+func SetWindowText(hwnd syscall.Handle, title string) {
+	text := syscall.StringToUTF16Ptr(title)
+	_SetWindowText.Call(uintptr(hwnd), uintptr(unsafe.Pointer(text)))
 }
 
 func ScreenToClient(hwnd syscall.Handle, p *Point) {


### PR DESCRIPTION
Currently, the Options can only be defined on the startup of the
window. This patch makes possible to change Options at anytime.

That patch also makes possible to change Size/MinSize/MaxSize/Title on
Windows and on Linux (x11).

Updates gio#193.