### PR TITLE
widget: fix Editor panic

### DIFF
--- a/widget/editor.go
+++ b/widget/editor.go
@@ -1186,6 +1186,7 @@ func (e *Editor) Selection() (start, end int) {
 // and end are in bytes, and represent offsets into the editor text. start and
 // end must be at a rune boundary.
 func (e *Editor) SetCaret(start, end int) {
+	e.makeValid()
 	// Constrain start and end to [0, e.Len()].
 	l := e.Len()
 	start = max(min(start, l), 0)

--- a/widget/editor_test.go
+++ b/widget/editor_test.go
@@ -34,6 +34,8 @@ func TestEditor(t *testing.T) {
 	fontSize := unit.Px(10)
 	font := text.Font{}
 
+	e.SetCaret(0, 0) // shouldn't panic
+	assertCaret(t, e, 0, 0, 0)
 	e.SetText("æbc\naøå•")
 	e.Layout(gtx, cache, font, fontSize)
 	assertCaret(t, e, 0, 0, 0)


### PR DESCRIPTION
If you created an Editor and immediately SetCaret, it panicked because e.lines was nil and it looked at e.lines[0].

- Add e.makeValid at the top of SetCaret.
- Add a test case for this situation.

Signed-off-by: Larry Clapp <larry@theclapp.org>