### PR TITLE
widget: fix bug how f.pos is calculated in widget.Float

### DIFF
--- a/widget/float.go
+++ b/widget/float.go
@@ -48,7 +48,7 @@ func (f *Float) Layout(gtx layout.Context, pointerMargin int, min, max float32) 
 		f.pos = xy / f.length
 		value = min + (max-min)*f.pos
 	} else if min != max {
-		f.pos = value/(max-min) - min
+		f.pos = (value - min) / (max - min)
 	}
 	// Unconditionally call setValue in case min, max, or value changed.
 	f.setValue(value, min, max)


### PR DESCRIPTION
setting minimum value for a Float never really worked, although min = 0 worked as intended which is why this probably went unnoticed.