### PR TITLE
cmd/gogio: [android] allow custom signature-key

### DIFF
--- a/cmd/gogio/build_info.go
+++ b/cmd/gogio/build_info.go
@@ -23,6 +23,8 @@ type buildInfo struct {
 	tags     string
 	target   string
 	version  int
+	key      string
+	password string
 }
 
 func newBuildInfo(pkgPath string) (*buildInfo, error) {
@@ -47,6 +49,8 @@ func newBuildInfo(pkgPath string) (*buildInfo, error) {
 		tags:     *extraTags,
 		target:   *target,
 		version:  *version,
+		key:      *signKey,
+		password: *signPass,
 	}
 	return bi, nil
 }

--- a/cmd/gogio/help.go
+++ b/cmd/gogio/help.go
@@ -59,4 +59,8 @@ The -work flag prints the path to the working directory and suppress
 its deletion.
 
 The -x flag will print all the external commands executed by the gogio tool.
+
+The -signkey flag specifies the path of the keystore, used for signing Android apk files.
+
+The -signpass flag specifies the password of the keystore, ignored if -signkey is not provided.
 `

--- a/cmd/gogio/main.go
+++ b/cmd/gogio/main.go
@@ -34,7 +34,9 @@ var (
 	linkMode      = flag.String("linkmode", "", "set the -linkmode flag of the go tool")
 	extraLdflags  = flag.String("ldflags", "", "extra flags to the Go linker")
 	extraTags     = flag.String("tags", "", "extra tags to the Go tool")
-	iconPath      = flag.String("icon", "", "Specify an icon for iOS and Android")
+	iconPath      = flag.String("icon", "", "specify an icon for iOS and Android")
+	signKey       = flag.String("signkey", "", "specify the path of the keystore to be used to sign Android apk files.")
+	signPass      = flag.String("signpass", "", "specify the password to decrypt the signkey.")
 )
 
 func main() {


### PR DESCRIPTION
That change makes possible to provide custom PKCS#12/JavaKeystore using `-key` and the password with `-pass`. Also, it's possible to use PKCS#8 key along with X509 certificate, using `-key` and `-cert`.

By default the gogio will use the `debug.keystore`, if no key is provided.