### PR TITLE
Expose Path for Circle, Rect and RRect

### DIFF
--- a/gpu/internal/rendertest/clip_test.go
+++ b/gpu/internal/rendertest/clip_test.go
@@ -37,29 +37,6 @@ func TestPaintClippedRect(t *testing.T) {
 	})
 }
 
-func TestPaintClippedBorder(t *testing.T) {
-	t.Skipf("doesn't render round-capped, round-joined dashes correctly")
-	run(t, func(o *op.Ops) {
-		var dashes clip.Dash
-		dashes.Begin(o)
-		dashes.Phase(1)
-		dashes.Dash(2)
-		dashes.Dash(1)
-
-		clip.Border{
-			Rect:   f32.Rect(25, 25, 60, 60),
-			Width:  4,
-			Dashes: dashes.End(),
-		}.Add(o)
-		paint.FillShape(o, red, clip.Rect(image.Rect(0, 0, 50, 50)).Op())
-	}, func(r result) {
-		r.expect(0, 0, colornames.White)
-		r.expect(25, 25, colornames.Red)
-		r.expect(50, 0, colornames.White)
-		r.expect(10, 50, colornames.White)
-	})
-}
-
 func TestPaintClippedCircle(t *testing.T) {
 	run(t, func(o *op.Ops) {
 		r := float32(10)

--- a/op/clip/shapes.go
+++ b/op/clip/shapes.go
@@ -51,11 +51,16 @@ type RRect struct {
 
 // Op returns the op for the rounded rectangle.
 func (rr RRect) Op(ops *op.Ops) Op {
-	return Outline{Path: rr.path(ops)}.Op()
+	return Outline{Path: rr.Path(ops)}.Op()
 }
 
-// path returns the path spec for the rounded rectangle.
-func (rr RRect) path(ops *op.Ops) PathSpec {
+// Add the rectangle clip.
+func (rr RRect) Add(ops *op.Ops) {
+	rr.Op(ops).Add(ops)
+}
+
+// Path returns the PathSpec for the rounded rectangle.
+func (rr RRect) Path(ops *op.Ops) PathSpec {
 	var p Path
 	p.Begin(ops)
 
@@ -91,11 +96,6 @@ func (rr RRect) path(ops *op.Ops) PathSpec {
 	return p.End()
 }
 
-// Add the rectangle clip.
-func (rr RRect) Add(ops *op.Ops) {
-	rr.Op(ops).Add(ops)
-}
-
 // Border represents a rectangular border.
 type Border struct {
 	// Rect is the bounds of the border.
@@ -115,7 +115,7 @@ func (b Border) Op(ops *op.Ops) Op {
 		Path: RRect{
 			Rect: b.Rect,
 			SE:   b.SE, SW: b.SW, NW: b.NW, NE: b.NE,
-		}.path(ops),
+		}.Path(ops),
 		Style: StrokeStyle{
 			Width: b.Width,
 		},
@@ -136,11 +136,16 @@ type Circle struct {
 
 // Op returns the op for the circle.
 func (c Circle) Op(ops *op.Ops) Op {
-	return Outline{Path: c.path(ops)}.Op()
+	return Outline{Path: c.Path(ops)}.Op()
 }
 
-// path returns the path spec for the circle.
-func (c Circle) path(ops *op.Ops) PathSpec {
+// Add the circle clip.
+func (c Circle) Add(ops *op.Ops) {
+	c.Op(ops).Add(ops)
+}
+
+// Path returns the PathSpec for the circle.
+func (c Circle) Path(ops *op.Ops) PathSpec {
 	var p Path
 	p.Begin(ops)
 

--- a/op/clip/shapes.go
+++ b/op/clip/shapes.go
@@ -96,38 +96,6 @@ func (rr RRect) Path(ops *op.Ops) PathSpec {
 	return p.End()
 }
 
-// Border represents a rectangular border.
-type Border struct {
-	// Rect is the bounds of the border.
-	Rect f32.Rectangle
-	// Width of the line tracing Rect.
-	Width  float32
-	Dashes DashSpec
-	// The corner radii.
-	SE, SW, NW, NE float32
-}
-
-// Op returns the clip operation for the border. Its area corresponds to a
-// stroked line that traces the border rectangle, optionally with rounded
-// corners and dashes.
-func (b Border) Op(ops *op.Ops) Op {
-	return Stroke{
-		Path: RRect{
-			Rect: b.Rect,
-			SE:   b.SE, SW: b.SW, NW: b.NW, NE: b.NE,
-		}.Path(ops),
-		Style: StrokeStyle{
-			Width: b.Width,
-		},
-		Dashes: b.Dashes,
-	}.Op()
-}
-
-// Add the border clip.
-func (rr Border) Add(ops *op.Ops) {
-	rr.Op(ops).Add(ops)
-}
-
 // Circle represents the clip area of a circle.
 type Circle struct {
 	Center f32.Point

--- a/widget/border.go
+++ b/widget/border.go
@@ -7,7 +7,6 @@ import (
 
 	"gioui.org/f32"
 	"gioui.org/layout"
-	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
@@ -23,24 +22,20 @@ type Border struct {
 func (b Border) Layout(gtx layout.Context, w layout.Widget) layout.Dimensions {
 	dims := w(gtx)
 	sz := dims.Size
+
 	rr := float32(gtx.Px(b.CornerRadius))
-	st := op.Save(gtx.Ops)
-	width := gtx.Px(b.Width)
-	sz.X -= width
-	sz.Y -= width
-	op.Offset(f32.Point{
-		X: float32(width) * 0.5,
-		Y: float32(width) * 0.5,
-	}).Add(gtx.Ops)
-	clip.Border{
-		Rect: f32.Rectangle{
-			Max: layout.FPt(sz),
-		},
-		NE: rr, NW: rr, SE: rr, SW: rr,
-		Width: float32(width),
-	}.Add(gtx.Ops)
-	paint.ColorOp{Color: b.Color}.Add(gtx.Ops)
-	paint.PaintOp{}.Add(gtx.Ops)
-	st.Load()
+	width := float32(gtx.Px(b.Width))
+
+	r := f32.Rectangle{Max: layout.FPt(sz)}
+	r = r.Add(f32.Point{X: width * 0.5, Y: width * 0.5})
+
+	paint.FillShape(gtx.Ops,
+		b.Color,
+		clip.Stroke{
+			Path:  clip.UniformRRect(r, rr).Path(gtx.Ops),
+			Style: clip.StrokeStyle{Width: width},
+		}.Op(),
+	)
+
 	return dims
 }


### PR DESCRIPTION
I'm not sure whether clip.Border should be deprecated or not, but I added the commit just in case.