### PR TITLE
app: [android] handle touch events from stylus

### DIFF
--- a/app/os_android.go
+++ b/app/os_android.go
@@ -648,6 +648,8 @@ func Java_org_gioui_GioView_onTouchEvent(env *C.JNIEnv, class C.jclass, handle C
 	switch tool {
 	case C.AMOTION_EVENT_TOOL_TYPE_FINGER:
 		src = pointer.Touch
+	case C.AMOTION_EVENT_TOOL_TYPE_STYLUS:
+		src = pointer.Touch
 	case C.AMOTION_EVENT_TOOL_TYPE_MOUSE:
 		src = pointer.Mouse
 	case C.AMOTION_EVENT_TOOL_TYPE_UNKNOWN:


### PR DESCRIPTION
This PR treats touch events from a stylus as if they were from a finger. I'm sure there's a philosophical debate as to whether a stylus is more like a mouse pointer than a finger, but I figured this would at least be a good first step to getting apps built with Gio to work mostly correctly with a stylus on Android devices.

Tested with the widgets in the `kitchen` example.