### PR TITLE
cmd/gogio: [android] add adaptive icon

### DIFF
--- a/cmd/gogio/androidbuild.go
+++ b/cmd/gogio/androidbuild.go
@@ -373,7 +373,8 @@ func exeAndroid(tmpDir string, tools *androidTools, bi *buildInfo, extraJars, pe
 	resDir := filepath.Join(tmpDir, "res")
 	valDir := filepath.Join(resDir, "values")
 	v21Dir := filepath.Join(resDir, "values-v21")
-	for _, dir := range []string{valDir, v21Dir} {
+	v26mipmapDir := filepath.Join(resDir, `mipmap-anydpi-v26`)
+	for _, dir := range []string{valDir, v21Dir, v26mipmapDir} {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
@@ -385,7 +386,20 @@ func exeAndroid(tmpDir string, tools *androidTools, bi *buildInfo, extraJars, pe
 			{path: filepath.Join("mipmap-xhdpi", "ic_launcher.png"), size: 96},
 			{path: filepath.Join("mipmap-xxhdpi", "ic_launcher.png"), size: 144},
 			{path: filepath.Join("mipmap-xxxhdpi", "ic_launcher.png"), size: 192},
+			{path: filepath.Join("mipmap-mdpi", "ic_launcher_adaptive.png"), size: 108},
+			{path: filepath.Join("mipmap-hdpi", "ic_launcher_adaptive.png"), size: 162},
+			{path: filepath.Join("mipmap-xhdpi", "ic_launcher_adaptive.png"), size: 216},
+			{path: filepath.Join("mipmap-xxhdpi", "ic_launcher_adaptive.png"), size: 324},
+			{path: filepath.Join("mipmap-xxxhdpi", "ic_launcher_adaptive.png"), size: 432},
 		})
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(filepath.Join(v26mipmapDir, `ic_launcher.xml`), []byte(`<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@mipmap/ic_launcher_adaptive" />
+    <foreground android:drawable="@mipmap/ic_launcher_adaptive" />
+</adaptive-icon>`), 0660)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change add the support for Adaptive-Icons (https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive).

Previously, some icons have some "white border" (see https://stackoverflow.com/questions/61603672/android-icon-has-white-border-on-pixel-3xl).