### PR TITLE
app: [android] fix vulkan crash when activity/surface is recreated

### DIFF
--- a/app/vulkan_android.go
+++ b/app/vulkan_android.go
@@ -84,5 +84,6 @@ func (c *wlVkContext) Refresh() error {
 	if err != nil {
 		return err
 	}
-	return c.ctx.refresh(surf, w, h)
+	c.surf = surf
+	return c.ctx.refresh(c.surf, w, h)
 }


### PR DESCRIPTION
On Android it's possible that the Activity/View must be restore. But,
before that patch, an new VkSurfaceKHR is created but never used and
that may lead to crash, in an attempt to destroy/use one invalid
surface.

Fixes gio#327

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>