### PR TITLE
app: [windows] fix maximized window size

### DIFF
--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -207,8 +207,6 @@ func (w *window) update() {
 		mode = Minimized
 	} else if p.IsMaximized() {
 		mode = Maximized
-		mi := windows.GetMonitorInfo(w.hwnd).Monitor
-		size = image.Point{X: int(mi.Right - mi.Left), Y: int(mi.Bottom - mi.Top)}
 	} else {
 		mode = Windowed
 	}


### PR DESCRIPTION
Previously, the window size is equal to the screen size. That doesn't
consider the size of the taskbar, causing the height be bigger than the
real height. Now, the maximized have the same behavior of windowed,
since both of them must include decorations and taskbar.

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>