### PR TITLE
gpu: prevent texture to be larger than MaxTextureSize

### DIFF
--- a/gpu/path.go
+++ b/gpu/path.go
@@ -261,6 +261,13 @@ func (s *fboSet) resize(ctx driver.Device, sizes []image.Point) {
 			}
 			// Add 5% extra space in each dimension to minimize resizing.
 			sz = sz.Mul(105).Div(100)
+			max := ctx.Caps().MaxTextureSize
+			if sz.Y > max {
+				sz.Y = max
+			}
+			if sz.X > max {
+				sz.X = max
+			}
 			tex, err := ctx.NewTexture(driver.TextureFormatFloat, sz.X, sz.Y, driver.FilterNearest, driver.FilterNearest,
 				driver.BufferBindingTexture|driver.BufferBindingFramebuffer)
 			if err != nil {


### PR DESCRIPTION
Before that change, the size of the texture could be higher than
the maximum supported by Vulkan.

Fixes: https://todo.sr.ht/~eliasnaur/gio/380

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>