### PR TITLE
app: [Android] improve keyboard hints

### DIFF
--- a/app/os_android.go
+++ b/app/os_android.go
@@ -1128,20 +1128,34 @@ func (w *window) ShowTextInput(show bool) {
 func (w *window) SetInputHint(mode key.InputHint) {
 	// Constants defined at https://developer.android.com/reference/android/text/InputType.
 	const (
-		TYPE_NULL                            = 0
-		TYPE_CLASS_TEXT                      = 1
-		TYPE_CLASS_NUMBER                    = 2
-		TYPE_NUMBER_FLAG_DECIMAL             = 8192
-		TYPE_NUMBER_FLAG_SIGNED              = 4096
-		TYPE_TEXT_FLAG_NO_SUGGESTIONS        = 524288
-		TYPE_TEXT_VARIATION_VISIBLE_PASSWORD = 144
+		TYPE_NULL = 0
+
+		TYPE_CLASS_TEXT                   = 1
+		TYPE_TEXT_VARIATION_EMAIL_ADDRESS = 32
+		TYPE_TEXT_VARIATION_URI           = 16
+		TYPE_TEXT_FLAG_CAP_SENTENCES      = 16384
+		TYPE_TEXT_FLAG_AUTO_CORRECT       = 32768
+
+		TYPE_CLASS_NUMBER        = 2
+		TYPE_NUMBER_FLAG_DECIMAL = 8192
+		TYPE_NUMBER_FLAG_SIGNED  = 4096
+
+		TYPE_CLASS_PHONE = 3
 	)
 
 	runInJVM(javaVM(), func(env *C.JNIEnv) {
 		var m jvalue
 		switch mode {
+		case key.HintText:
+			m = TYPE_CLASS_TEXT | TYPE_TEXT_FLAG_AUTO_CORRECT | TYPE_TEXT_FLAG_CAP_SENTENCES
 		case key.HintNumeric:
 			m = TYPE_CLASS_NUMBER | TYPE_NUMBER_FLAG_DECIMAL | TYPE_NUMBER_FLAG_SIGNED
+		case key.HintEmail:
+			m = TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_EMAIL_ADDRESS
+		case key.HintURL:
+			m = TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_URI
+		case key.HintTelephone:
+			m = TYPE_CLASS_PHONE
 		default:
 			m = TYPE_CLASS_TEXT
 		}


### PR DESCRIPTION
This patch adds support for the following KeyboardHint: Text, Email,
Telephone and URL. Also, fixes crashes related to Samsung keyboards.

Fixes: https://todo.sr.ht/~eliasnaur/gio/404

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>