### PR TITLE
app: [windows] fix keyboard focus

### DIFF
--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -53,6 +53,7 @@ type window struct {
 	placement *windows.WindowPlacement
 
 	animating bool
+	focused   bool
 
 	deltas     winDeltas
 	borderSize image.Point
@@ -277,8 +278,10 @@ func windowProc(hwnd syscall.Handle, msg uint32, wParam, lParam uintptr) uintptr
 			Type: pointer.Cancel,
 		})
 	case windows.WM_SETFOCUS:
+		w.focused = true
 		w.w.Event(key.FocusEvent{Focus: true})
 	case windows.WM_KILLFOCUS:
+		w.focused = false
 		w.w.Event(key.FocusEvent{Focus: false})
 	case windows.WM_NCHITTEST:
 		if w.config.Decorated {
@@ -470,6 +473,10 @@ func (w *window) hitTest(x, y int) uintptr {
 }
 
 func (w *window) pointerButton(btn pointer.Buttons, press bool, lParam uintptr, kmods key.Modifiers) {
+	if !w.focused {
+		windows.SetFocus(w.hwnd)
+	}
+
 	var typ pointer.Type
 	if press {
 		typ = pointer.Press


### PR DESCRIPTION
On Windows, it's required to SetFocus to receive keyboard events.
Previously, Gio doesn't set focus on the current window. In some
edge cases, it prevents Gio from getting keyboard events.

That is more noticeable when spawning children's windows or parent
windows. In such a case, the child window can steal keyboard focus,
and Gio will never recover it. Now, it will retrieve the focus when
using key.FocusOp.

Signed-off-by: Inkeliz <inkeliz@inkeliz.com>