### PR TITLE
app: [ios] add ignoreSafeAreaInsets config (iOS >= 11.*)

### DIFF
--- a/app/os.go
+++ b/app/os.go
@@ -43,6 +43,8 @@ type Config struct {
 	CustomRenderer bool
 	// Decorated reports whether window decorations are provided automatically.
 	Decorated bool
+	// Ignore safe area insets for iOS >= 11.
+	IgnoreSafeAreaInsets bool
 }
 
 // ConfigEvent is sent whenever the configuration of a Window changes.

--- a/app/window.go
+++ b/app/window.go
@@ -1130,6 +1130,13 @@ func NavigationColor(color color.NRGBA) Option {
 	}
 }
 
+// IgnoreSafeAreaInsets ignores safe area insets for iOS >= 11.
+func IgnoreSafeAreaInsets(ignore bool) Option {
+	return func(_ unit.Metric, cnf *Config) {
+		cnf.IgnoreSafeAreaInsets = ignore
+	}
+}
+
 // CustomRenderer controls whether the window contents is
 // rendered by the client. If true, no GPU context is created.
 //


### PR DESCRIPTION
By default status bar on iPhones with notch is white (bgColor).
I think we need to add an option to allow applications control unsafe areas themself.

<table>
  <tr>
    <th>Before</th>
    <th>After</th> 
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/9019326/177038211-4ba990e9-950d-4f59-8a45-8a1433393389.jpg" width="300"></td>
    <td><img src="https://user-images.githubusercontent.com/9019326/177037825-193b6efa-3678-4dff-a225-142d2a367a9b.jpg" width="300"></td>
  </tr>
</table>


