### PR TITLE
app: [android] use GioView  inside FrameLayout

### DIFF
--- a/app/GioActivity.java
+++ b/app/GioActivity.java
@@ -5,16 +5,30 @@ package org.gioui;
 import android.app.Activity;
 import android.os.Bundle;
 import android.content.res.Configuration;
+import android.view.ViewGroup;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 public final class GioActivity extends Activity {
 	private GioView view;
+	public FrameLayout layer;
 
 	@Override public void onCreate(Bundle state) {
-		super.onCreate(state);
+            super.onCreate(state);
 
-		this.view = new GioView(this);
+            layer = new FrameLayout(this);
+            view = new GioView(this);
 
-		setContentView(view);
+            view.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            ));
+            view.setFocusable(true);
+            view.setFocusableInTouchMode(true);
+
+            layer.addView(view);
+            setContentView(layer);
 	}
 
 	@Override public void onDestroy() {


### PR DESCRIPTION
Before that change, on Android, was impossible to overlay GioView with
a custom view. This change adds FrameLayout and renders GioView into
that, allowing to use `addView` from Android API.

This change also adds `Layer` on ViewEvent, which represents the
FrameLayout.

Fixes: https://todo.sr.ht/~eliasnaur/gio/427
Signed-off-by: Inkeliz <inkeliz@inkeliz.com>