### PR TITLE
layout: Add convenience method LayoutW to wrap Layout

### DIFF
--- a/layout/alloc_test.go
+++ b/layout/alloc_test.go
@@ -30,6 +30,23 @@ func TestStackAllocs(t *testing.T) {
 	}
 }
 
+func TestStackLayoutWAllocs(t *testing.T) {
+	var ops op.Ops
+	allocs := testing.AllocsPerRun(1, func() {
+		ops.Reset()
+		gtx := Context{
+			Ops: &ops,
+		}
+		Stack{}.LayoutW(Stacked(func(gtx Context) Dimensions {
+			return Dimensions{Size: image.Point{X: 50, Y: 50}}
+		}),
+		)(gtx)
+	})
+	if allocs != 0 {
+		t.Errorf("expected no allocs, got %f", allocs)
+	}
+}
+
 func TestFlexAllocs(t *testing.T) {
 	var ops op.Ops
 	allocs := testing.AllocsPerRun(1, func() {
@@ -42,6 +59,22 @@ func TestFlexAllocs(t *testing.T) {
 				return Dimensions{Size: image.Point{X: 50, Y: 50}}
 			}),
 		)
+	})
+	if allocs != 0 {
+		t.Errorf("expected no allocs, got %f", allocs)
+	}
+}
+
+func TestFlexLayoutWAllocs(t *testing.T) {
+	var ops op.Ops
+	allocs := testing.AllocsPerRun(1, func() {
+		ops.Reset()
+		gtx := Context{
+			Ops: &ops,
+		}
+		Flex{}.LayoutW(Rigid(func(gtx Context) Dimensions {
+			return Dimensions{Size: image.Point{X: 50, Y: 50}}
+		}))(gtx)
 	})
 	if allocs != 0 {
 		t.Errorf("expected no allocs, got %f", allocs)

--- a/layout/flex.go
+++ b/layout/flex.go
@@ -77,6 +77,12 @@ func Flexed(weight float32, widget Widget) FlexChild {
 	}
 }
 
+func (f Flex) LayoutW(children ...FlexChild) Widget {
+	return func(gtx Context) Dimensions {
+		return f.Layout(gtx, children...)
+	}
+}
+
 // Layout a list of children. The position of the children are
 // determined by the specified order, but Rigid children are laid out
 // before Flexed children.

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -109,6 +109,12 @@ type Inset struct {
 	Top, Bottom, Left, Right unit.Dp
 }
 
+func (in Inset) LayoutW(w Widget) Widget {
+	return func(gtx Context) Dimensions {
+		return in.Layout(gtx, w)
+	}
+}
+
 // Layout a widget.
 func (in Inset) Layout(gtx Context, w Widget) Dimensions {
 	top := gtx.Dp(in.Top)
@@ -148,6 +154,12 @@ func (in Inset) Layout(gtx Context, w Widget) Dimensions {
 // edges.
 func UniformInset(v unit.Dp) Inset {
 	return Inset{Top: v, Right: v, Bottom: v, Left: v}
+}
+
+func (d Direction) LayoutW(w Widget) Widget {
+	return func(gtx Context) Dimensions {
+		return d.Layout(gtx, w)
+	}
 }
 
 // Layout a widget according to the direction.

--- a/layout/list.go
+++ b/layout/list.go
@@ -105,6 +105,12 @@ func (l *List) init(gtx Context, len int) {
 	}
 }
 
+func (l *List) LayoutW(len int, w ListElement) Widget {
+	return func(gtx Context) Dimensions {
+		return l.Layout(gtx, len, w)
+	}
+}
+
 // Layout a List of len items, where each item is implicitly defined
 // by the callback w. Layout can handle very large lists because it only calls
 // w to fill its viewport and the distance scrolled, if any.

--- a/layout/stack.go
+++ b/layout/stack.go
@@ -44,6 +44,12 @@ func Expanded(w Widget) StackChild {
 	}
 }
 
+func (f Stack) LayoutW(children ...StackChild) Widget {
+	return func(gtx Context) Dimensions {
+		return f.Layout(gtx, children...)
+	}
+}
+
 // Layout a stack of children. The position of the children are
 // determined by the specified order, but Stacked children are laid out
 // before Expanded children.


### PR DESCRIPTION
This was discussed on slack
https://gophers.slack.com/archives/CM87SNCGM/p1658574692395529

The idea is to make the Layout method more interop with other widgets that needs
other widgets as children.

# Slack original message: 

while using Gio I found that using layouts as children for other layouts or passing a layout as widget to another Layout function needs me to wrap it in a closure. as follows

> Flex{}.Layout(ctx, Rigid(func(c Context) Dimensions { return Flex{}.Layout(ctx, children...) }))

While if the Flex.Layout method has this signature func (f Flex) Layout(children ...FlexChild) func(gtx Context) Dimensions) then the usage can be simpler

> Flex{}.Layout(ctx, Rigid(Flex{}.Layout(children...)))

and that goes to any method that takes Context the more params. if it's changed to a function that takes the more params and return a function of `layout.Widget` it would make it easier to use with anything that needs a widget.

in my code I'm doing these wrappers (it's easy to do) but I thought that can make it easier for everyone to change it in future releases of Gio. 

# Changes
- This introduced another method `LayoutW` W for Widget.
- The new method takes all parameters of `Layout` minus `Context` and returns a Widget function.
- Tests for Stack layout and Flex layout are replicated to use `LayoutW` to make sure there are no allocations for the new approach.
