### PR TITLE
app,io/key: Add key code for key.Event

### DIFF
--- a/app/os_android.go
+++ b/app/os_android.go
@@ -896,7 +896,7 @@ func runInJVM(jvm *C.JavaVM, f func(env *C.JNIEnv)) {
 	f(env)
 }
 
-func convertKeyCode(code C.jint) (string, bool) {
+func convertKeyCode(code C.jint) string {
 	var n string
 	switch code {
 	case C.AKEYCODE_FORWARD_DEL:
@@ -923,10 +923,8 @@ func convertKeyCode(code C.jint) (string, bool) {
 		n = key.NameLeftArrow
 	case C.AKEYCODE_DPAD_RIGHT:
 		n = key.NameRightArrow
-	default:
-		return "", false
 	}
-	return n, true
+	return n
 }
 
 //export Java_org_gioui_GioView_onKeyEvent
@@ -936,13 +934,15 @@ func Java_org_gioui_GioView_onKeyEvent(env *C.JNIEnv, class C.jclass, handle C.j
 		w.callbacks.ClickFocus()
 		return
 	}
-	if n, ok := convertKeyCode(keyCode); ok {
-		state := key.Release
-		if pressed == C.JNI_TRUE {
-			state = key.Press
-		}
-		w.callbacks.Event(key.Event{Name: n, State: state})
+	state := key.Release
+	if pressed == C.JNI_TRUE {
+		state = key.Press
 	}
+	w.callbacks.Event(key.Event{
+		Code:  int(keyCode),
+		Name:  convertKeyCode(keyCode),
+		State: state,
+	})
 	if pressed == C.JNI_TRUE && r != 0 && r != '\n' { // Checking for "\n" to prevent duplication with key.NameEnter (gio#224).
 		w.callbacks.EditorInsert(string(rune(r)))
 	}

--- a/app/os_js.go
+++ b/app/os_js.go
@@ -358,15 +358,14 @@ func (w *window) keyboard(hint key.InputHint) {
 }
 
 func (w *window) keyEvent(e js.Value, ks key.State) {
+	c := e.Get("keyCode").Int()
 	k := e.Get("key").String()
-	if n, ok := translateKey(k); ok {
-		cmd := key.Event{
-			Name:      n,
-			Modifiers: modifiersFor(e),
-			State:     ks,
-		}
-		w.w.Event(cmd)
-	}
+	w.w.Event(key.Event{
+		Code:      c,
+		Name:      translateKey(k),
+		Modifiers: modifiersFor(e),
+		State:     ks,
+	})
 }
 
 // modifiersFor returns the modifier set for a DOM MouseEvent or
@@ -737,9 +736,8 @@ func osMain() {
 	select {}
 }
 
-func translateKey(k string) (string, bool) {
-	var n string
-
+func translateKey(k string) string {
+	n := k
 	switch k {
 	case "ArrowUp":
 		n = key.NameUpArrow
@@ -805,11 +803,10 @@ func translateKey(k string) (string, bool) {
 		r, s := utf8.DecodeRuneInString(k)
 		// If there is exactly one printable character, return that.
 		if s == len(k) && unicode.IsPrint(r) {
-			return strings.ToUpper(k), true
+			n = strings.ToUpper(k)
 		}
-		return "", false
 	}
-	return n, true
+	return n
 }
 
 func (_ ViewEvent) ImplementsEvent() {}

--- a/app/os_macos.go
+++ b/app/os_macos.go
@@ -486,13 +486,12 @@ func gio_onKeys(view, cstr C.CFTypeRef, ti C.double, mods C.NSUInteger, keyDown 
 	}
 	w := mustView(view)
 	for _, k := range str {
-		if n, ok := convertKey(k); ok {
-			w.w.Event(key.Event{
-				Name:      n,
-				Modifiers: kmods,
-				State:     ks,
-			})
-		}
+		w.w.Event(key.Event{
+			Code:      int(k),
+			Name:      convertKey(k),
+			Modifiers: kmods,
+			State:     ks,
+		})
 	}
 }
 
@@ -892,8 +891,8 @@ func osMain() {
 	C.gio_main()
 }
 
-func convertKey(k rune) (string, bool) {
-	var n string
+func convertKey(k rune) string {
+	n := string(k)
 	switch k {
 	case 0x1b:
 		n = key.NameEscape
@@ -951,12 +950,11 @@ func convertKey(k rune) (string, bool) {
 		n = key.NameSpace
 	default:
 		k = unicode.ToUpper(k)
-		if !unicode.IsPrint(k) {
-			return "", false
+		if unicode.IsPrint(k) {
+			n = string(k)
 		}
-		n = string(k)
 	}
-	return n, true
+	return n
 }
 
 func convertMods(mods C.NSUInteger) key.Modifiers {

--- a/io/key/key.go
+++ b/io/key/key.go
@@ -116,6 +116,8 @@ type FocusEvent struct {
 // An Event is generated when a key is pressed. For text input
 // use EditEvent.
 type Event struct {
+	// Code of the key. It is platform-specific, thus non-portable.
+	Code int
 	// Name of the key. For letters, the upper case form is used, via
 	// unicode.ToUpper. The shift modifier is taken into account, all other
 	// modifiers are ignored. For example, the "shift-1" and "ctrl-shift-1"


### PR DESCRIPTION
Add non-portable key code to the `key.Event` type. This allows users to handle platform-specific key codes in the application code. Backends will now always generate input events, even for keys with no well-known names. Previously backends only generated events for keys they recognized.

Signed-off-by: Denys Smirnov <dennwc@pm.me>