### PR TITLE
Add ArrowsNavigation option

### DIFF
--- a/app/os.go
+++ b/app/os.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"image"
 	"image/color"
+	"runtime"
 
 	"gioui.org/io/key"
 
@@ -43,9 +44,16 @@ type Config struct {
 	CustomRenderer bool
 	// Decorated reports whether window decorations are provided automatically.
 	Decorated bool
+	// ArrowsNavigation allows directional navigation with arrow keys or dpad.
+	// It's enabled by default on mobile (Android and iOS) and disabled for desktop (which uses Tab instead).
+	ArrowsNavigation bool
 	// decoHeight is the height of the fallback decoration for platforms such
 	// as Wayland that may need fallback client-side decorations.
 	decoHeight unit.Dp
+}
+
+func (c *Config) defaults() {
+	c.ArrowsNavigation = runtime.GOOS == "ios" || runtime.GOOS == "android"
 }
 
 // ConfigEvent is sent whenever the configuration of a Window changes.


### PR DESCRIPTION
Directional navigation with arrow keys/dpad was only enabled on mobile targets (Android, iOS) with no way to enable it for desktop.

This change adds a new `Option` for it, which is useful for game UIs and other apps that allow faster keyboard navigation.

Signed-off-by: Denys Smirnov <dennwc@pm.me>