### PR TITLE
app: wayland force redraw on config change

### DIFF
--- a/app/os_wayland.go
+++ b/app/os_wayland.go
@@ -1079,6 +1079,7 @@ func (w *window) Configure(options []Option) {
 		w.setWindowConstraints()
 	}
 	w.w.Event(ConfigEvent{Config: w.config})
+	w.redraw = true
 }
 
 func (w *window) setWindowConstraints() {


### PR DESCRIPTION
When applying window config on runtime, it is nessesary to do full redraw in order to changed config option to apply correctly. This fixes a bug where e.g window size change renders next frame in updated dimensions while native window is not scaled yet since it was waiting for stage event to apply resize.