### PR TITLE
various cleanups

### DIFF
--- a/app/os_wayland.go
+++ b/app/os_wayland.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -1018,7 +1017,7 @@ func (w *window) ReadClipboard() {
 	// Don't let slow clipboard transfers block event loop.
 	go func() {
 		defer r.Close()
-		data, _ := ioutil.ReadAll(r)
+		data, _ := io.ReadAll(r)
 		w.clipReads <- clipboard.Event{Text: string(data)}
 		w.Wakeup()
 	}()

--- a/gpu/compute.go
+++ b/gpu/compute.go
@@ -12,9 +12,9 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
-	"io/ioutil"
 	"math"
 	"math/bits"
+	"os"
 	"runtime"
 	"sort"
 	"time"
@@ -655,7 +655,7 @@ func (g *compute) dumpAtlases() {
 		if err := png.Encode(&buf, nrgba); err != nil {
 			panic(err)
 		}
-		if err := ioutil.WriteFile(fmt.Sprintf("dump-%d.png", i), buf.Bytes(), 0600); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("dump-%d.png", i), buf.Bytes(), 0600); err != nil {
 			panic(err)
 		}
 	}

--- a/gpu/headless/driver_test.go
+++ b/gpu/headless/driver_test.go
@@ -8,7 +8,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"testing"
 
@@ -202,5 +202,5 @@ func saveImage(file string, img image.Image) error {
 	if err := png.Encode(&buf, img); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(file, buf.Bytes(), 0666)
+	return os.WriteFile(file, buf.Bytes(), 0666)
 }

--- a/gpu/internal/rendertest/util_test.go
+++ b/gpu/internal/rendertest/util_test.go
@@ -10,7 +10,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -161,7 +160,7 @@ func verifyRef(t *testing.T, img *image.RGBA, frame int) (ok bool) {
 		saveImage(t, path, img)
 		return true
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Error("could not open ref:", err)
 		return
@@ -286,7 +285,7 @@ func saveImage(t testing.TB, file string, img *image.RGBA) {
 		t.Error(err)
 		return
 	}
-	if err := ioutil.WriteFile(file, buf.Bytes(), 0666); err != nil {
+	if err := os.WriteFile(file, buf.Bytes(), 0666); err != nil {
 		t.Error(err)
 		return
 	}

--- a/text/gotext_test.go
+++ b/text/gotext_test.go
@@ -258,7 +258,7 @@ func makeTestText(shaper *shaperImpl, primaryDir system.TextDirection, fontSize,
 	}
 	simpleText := shaper.shapeAndWrapText(shaper.orderer.sortedFacesForStyle(Font{}), Parameters{PxPerEm: fixed.I(fontSize)}, lineWidth, locale, []rune(simpleSource))
 	complexText := shaper.shapeAndWrapText(shaper.orderer.sortedFacesForStyle(Font{}), Parameters{PxPerEm: fixed.I(fontSize)}, lineWidth, locale, []rune(complexSource))
-	shaper = testShaper(rtlFace, ltrFace)
+	testShaper(rtlFace, ltrFace)
 	return simpleText, complexText
 }
 

--- a/text/text.go
+++ b/text/text.go
@@ -53,22 +53,23 @@ const (
 )
 
 const (
-	Thin       Weight = 100 - 400
-	Hairline   Weight = Thin
-	ExtraLight Weight = 200 - 400
-	UltraLight Weight = ExtraLight
-	Light      Weight = 300 - 400
-	Normal     Weight = 400 - 400
-	Medium     Weight = 500 - 400
-	SemiBold   Weight = 600 - 400
-	DemiBold   Weight = SemiBold
-	Bold       Weight = 700 - 400
-	ExtraBold  Weight = 800 - 400
-	UltraBold  Weight = ExtraBold
-	Black      Weight = 900 - 400
-	Heavy      Weight = Black
-	ExtraBlack Weight = 950 - 400
-	UltraBlack Weight = ExtraBlack
+	Thin       Weight = -300
+	ExtraLight Weight = -200
+	Light      Weight = -100
+	Normal     Weight = 0
+	Medium     Weight = 100
+	SemiBold   Weight = 200
+	Bold       Weight = 300
+	ExtraBold  Weight = 400
+	Black      Weight = 500
+
+	Hairline   = Thin
+	UltraLight = ExtraLight
+	DemiBold   = SemiBold
+	UltraBold  = ExtraBold
+	Heavy      = Black
+	ExtraBlack = Black + 50
+	UltraBlack = ExtraBlack
 )
 
 func (a Alignment) String() string {

--- a/widget/editor_test.go
+++ b/widget/editor_test.go
@@ -117,12 +117,12 @@ func TestEditorReadOnly(t *testing.T) {
 	if cStart != cEnd {
 		t.Errorf("unexpected initial caret positions")
 	}
-	dims := e.Layout(gtx, cache, font, fontSize, nil)
+	e.Layout(gtx, cache, font, fontSize, nil)
 
 	// Select everything.
 	gtx.Ops.Reset()
 	gtx.Queue = &testQueue{events: []event.Event{key.Event{Name: "A", Modifiers: key.ModShortcut}}}
-	dims = e.Layout(gtx, cache, font, fontSize, nil)
+	e.Layout(gtx, cache, font, fontSize, nil)
 	textContent := e.Text()
 	cStart2, cEnd2 := e.Selection()
 	if cStart2 > cEnd2 {
@@ -138,7 +138,7 @@ func TestEditorReadOnly(t *testing.T) {
 	// Type some new characters.
 	gtx.Ops.Reset()
 	gtx.Queue = &testQueue{events: []event.Event{key.EditEvent{Range: key.Range{Start: cStart2, End: cEnd2}, Text: "something else"}}}
-	dims = e.Layout(gtx, cache, font, fontSize, nil)
+	e.Layout(gtx, cache, font, fontSize, nil)
 	textContent2 := e.Text()
 	if textContent2 != textContent {
 		t.Errorf("readonly editor modified by key.EditEvent")
@@ -147,7 +147,7 @@ func TestEditorReadOnly(t *testing.T) {
 	// Try to delete selection.
 	gtx.Ops.Reset()
 	gtx.Queue = &testQueue{events: []event.Event{key.Event{Name: key.NameDeleteBackward}}}
-	dims = e.Layout(gtx, cache, font, fontSize, nil)
+	dims := e.Layout(gtx, cache, font, fontSize, nil)
 	textContent2 = e.Text()
 	if textContent2 != textContent {
 		t.Errorf("readonly editor modified by delete key.Event")

--- a/widget/selectable.go
+++ b/widget/selectable.go
@@ -45,7 +45,6 @@ func (s stringSource) ReadAt(b []byte, offset int64) (int, error) {
 
 // ReplaceRunes is unimplemented, as a stringSource is immutable.
 func (s stringSource) ReplaceRunes(byteOffset, runeCount int64, str string) {
-	return
 }
 
 // Selectable holds text selection state.


### PR DESCRIPTION
- various cleanups

Ineffective assignments (that could be bugs) remain at:
- `layout/list.go:292`
- `text/gotext_test.go:253,256`
- `text/gotext.go:719`

Also there are about a dozen unchecked error returns.