### PR TITLE
macOS: external drag and drop support

### DIFF
--- a/app/os_macos.go
+++ b/app/os_macos.go
@@ -8,6 +8,10 @@ package app
 import (
 	"errors"
 	"image"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 	"unicode"
@@ -18,6 +22,7 @@ import (
 	"gioui.org/io/key"
 	"gioui.org/io/pointer"
 	"gioui.org/io/system"
+	"gioui.org/io/transfer"
 	"gioui.org/unit"
 
 	_ "gioui.org/internal/cocoainit"
@@ -554,6 +559,22 @@ func gio_onMouse(view, evt C.CFTypeRef, cdir C.int, cbtn C.NSInteger, x, y, dx, 
 		Position:  pos,
 		Scroll:    f32.Point{X: dxf, Y: dyf},
 		Modifiers: convertMods(mods),
+	})
+}
+
+//export gio_onExternalDrop
+func gio_onExternalDrop(view C.CFTypeRef, path *C.char) {
+	fileUrl := C.GoString(path)
+	w := mustView(view)
+
+	fileExtension := filepath.Ext(fileUrl)
+	mime := mime.TypeByExtension(fileExtension)
+
+	w.w.Event(transfer.DataEvent{
+		Type: mime,
+		Open: func() (io.ReadCloser, error) {
+			return os.Open(fileUrl)
+		},
 	})
 }
 

--- a/app/os_macos.m
+++ b/app/os_macos.m
@@ -110,6 +110,20 @@ static void handleMouse(NSView *view, NSEvent *event, int typ, CGFloat dx, CGFlo
 - (void)mouseDragged:(NSEvent *)event {
 	handleMouse(self, event, MOUSE_MOVE, 0, 0);
 }
+-(NSDragOperation)draggingEntered:(id < NSDraggingInfo >)sender
+{
+	return NSDragOperationCopy;
+}
+- (void)draggingEnded:(id <NSDraggingInfo>)sender
+{
+	NSPasteboard* pbrd = [sender draggingPasteboard];
+	NSArray* droppedFiles = [pbrd propertyListForType:NSFilenamesPboardType];
+
+	for (NSString* filePath in droppedFiles) {
+		NSURL* url = [NSURL fileURLWithPath:filePath];
+		gio_onExternalDrop((__bridge CFTypeRef)self, (char*)[[url path] UTF8String]);
+	}
+}
 - (void)scrollWheel:(NSEvent *)event {
 	CGFloat dx = -event.scrollingDeltaX;
 	CGFloat dy = -event.scrollingDeltaY;
@@ -366,6 +380,7 @@ CFTypeRef gio_createView(void) {
 	@autoreleasepool {
 		NSRect frame = NSMakeRect(0, 0, 0, 0);
 		GioView* view = [[GioView alloc] initWithFrame:frame];
+		[view registerForDraggedTypes: [NSArray arrayWithObjects:NSTIFFPboardType, NSFilenamesPboardType, nil]];
 		view.wantsLayer = YES;
 		view.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
 		return CFBridgingRetain(view);

--- a/io/router/router.go
+++ b/io/router/router.go
@@ -182,6 +182,8 @@ func (q *Router) Queue(events ...event.Event) bool {
 			}
 		case clipboard.Event:
 			q.cqueue.Push(e, &q.handlers)
+		case transfer.DataEvent:
+			q.pointer.queue.notifyPotentialTargets(&pointerHandler{sourceMimes: []string{e.Type}}, &q.handlers, e)
 		}
 	}
 	return q.handlers.HadEvents()

--- a/io/transfer/transfer.go
+++ b/io/transfer/transfer.go
@@ -103,7 +103,7 @@ type DataEvent struct {
 	Type string
 	// Open returns the transfer data. It is only valid to call Open in the frame
 	// the DataEvent is received. The caller must close the return value after use.
-	Open func() io.ReadCloser
+	Open func() (io.ReadCloser, error)
 }
 
 func (DataEvent) ImplementsEvent() {}


### PR DESCRIPTION
Adds some very basic DnD support for external files on macOS.

- I don't understand event routing yet, so the implementation is probably incorrect.
- Support for Windows and Linux missing
- It probably should be possible to add this for specific widgets and not for the whole window.

### Usage

**go.mod**
```go
module main

go 1.19

replace gioui.org => github.com/StarHack/gio v0.0.0-20230421195057-eb440387490a

require gioui.org v0.0.0-20230414223051-b6e0376ad2fe

require (
	gioui.org/cpu v0.0.0-20210817075930-8d6a761490d2 // indirect
	gioui.org/shader v1.0.6 // indirect
	github.com/benoitkugler/textlayout v0.3.0 // indirect
	github.com/go-text/typesetting v0.0.0-20221214153724-0399769901d5 // indirect
	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95 // indirect
	golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91 // indirect
	golang.org/x/image v0.0.0-20220722155232-062f8c9fd539 // indirect
	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
	golang.org/x/text v0.7.0 // indirect
)
```

**main.go**
```go
package main

import (
	"fmt"
	"image"
	_ "image/gif"
	"io"
	"os"

	"gioui.org/app"
	"gioui.org/io/system"
	"gioui.org/io/transfer"
	"gioui.org/layout"
	"gioui.org/op"
	"gioui.org/op/paint"
	"gioui.org/widget"
)

func loadImage(file io.ReadCloser) (widget.Image, error) {
	img := widget.Image{}
	decImg, _, err := image.Decode(file)
	if err != nil {
		return img, err
	}
	img.Src = paint.NewImageOp(decImg)
	return img, nil
}

func main() {
	go func() {
		w := app.NewWindow()
		var ops op.Ops

		f, _ := os.Open("img/placeholder.png")
		img, _ := loadImage(f)

		tag := new(int)

		for {
			e := <-w.Events()

			switch e := e.(type) {
			case system.DestroyEvent:
				return
			case system.FrameEvent:
				gtx := layout.NewContext(&ops, e)

				transfer.TargetOp{
					Tag:  tag,
					Type: "image/png",
				}.Add(&ops)

				for _, gtxEvent := range gtx.Events(tag) {
					switch e := gtxEvent.(type) {
					case transfer.DataEvent:
						file, err := e.Open()
						newImg, err := loadImage(file)
						if err == nil {
							img = newImg
						} else {
							fmt.Println(err)
						}
					}
				}

				img.Layout(gtx)
				e.Frame(gtx.Ops)
			}
		}
	}()
	app.Main()
}
```

### Demo

https://user-images.githubusercontent.com/5388534/221357178-7e800dc7-9513-4575-9e84-1b191a6cb406.mov
