### PR TITLE
app: [Android] Set high refresh rate on startup

### DIFF
--- a/app/GioView.java
+++ b/app/GioView.java
@@ -26,6 +26,7 @@ import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.Choreographer;
+import android.view.Display;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -472,6 +473,67 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 			.setInsertionMarkerLocation(caretX, caretTop, caretBase, caretBottom, 0)
 			.build();
 		imm.updateCursorAnchorInfo(this, inf);
+	}
+
+	int countDisplayModes() {
+		Context context = getContext();
+		Display display = context.getDisplay();
+		Display.Mode[] supportedModes = display.getSupportedModes();
+		return supportedModes.length;
+	}
+
+	/**
+	 * Pick the highest refresh rate supported at the current resolution. Needs to be called from the main
+	 * thread.
+	 */
+	void setHighRefreshRate() {
+		Context context = getContext();
+		Display display = context.getDisplay();
+		Display.Mode currentMode = display.getMode();
+		int currentWidth = currentMode.getPhysicalWidth();
+		int currentHeight = currentMode.getPhysicalHeight();
+		Display.Mode[] supportedModes = display.getSupportedModes();
+		
+		float minRefreshRate = -1;
+		float maxRefreshRate = -1;
+		float bestRefreshRate = -1;
+		int bestModeId = -1;
+		for (Display.Mode mode : supportedModes) {
+			float refreshRate = mode.getRefreshRate();
+			float width = mode.getPhysicalWidth();
+			float height = mode.getPhysicalHeight();
+			
+			if (minRefreshRate == -1 || refreshRate < minRefreshRate) {
+				minRefreshRate = refreshRate;
+			}
+			if (maxRefreshRate == -1 || refreshRate > maxRefreshRate) {
+				maxRefreshRate = refreshRate;
+			}
+
+			boolean refreshRateIsBetter = bestRefreshRate == -1 || refreshRate > bestRefreshRate;
+			if (width == currentWidth && height == currentHeight && refreshRateIsBetter) {
+				int modeId = mode.getModeId();
+				bestRefreshRate = refreshRate;
+				bestModeId = modeId;
+			}
+		}
+
+		if (bestModeId == -1) {
+			// Not expecting this but just in case
+			return;
+		}
+
+		if (minRefreshRate == maxRefreshRate) {
+			// Can't improve the refresh rate
+			return;
+		}
+
+		Window window = ((Activity) context).getWindow();
+		WindowManager.LayoutParams layoutParams = window.getAttributes();
+		layoutParams.preferredDisplayModeId = bestModeId;
+
+		// This is the call that needs to happen on the main thread
+		window.setAttributes(layoutParams);
 	}
 
 	static private native long onCreateView(GioView view);

--- a/app/GioView.java
+++ b/app/GioView.java
@@ -106,6 +106,8 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 			scrollYScale = px;
 		}
 
+		setHighRefreshRate();
+
 		accessManager = (AccessibilityManager)context.getSystemService(Context.ACCESSIBILITY_SERVICE);
 		imm = (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
 		nhandle = onCreateView(this);
@@ -475,24 +477,18 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 		imm.updateCursorAnchorInfo(this, inf);
 	}
 
-	int countDisplayModes() {
-		Context context = getContext();
-		Display display = context.getDisplay();
-		Display.Mode[] supportedModes = display.getSupportedModes();
-		return supportedModes.length;
-	}
-
-	/**
-	 * Pick the highest refresh rate supported at the current resolution. Needs to be called from the main
-	 * thread.
-	 */
 	void setHighRefreshRate() {
 		Context context = getContext();
 		Display display = context.getDisplay();
+		Display.Mode[] supportedModes = display.getSupportedModes();
+		if (supportedModes.length <= 1) {
+			// Nothing to set
+			return;
+		}
+
 		Display.Mode currentMode = display.getMode();
 		int currentWidth = currentMode.getPhysicalWidth();
 		int currentHeight = currentMode.getPhysicalHeight();
-		Display.Mode[] supportedModes = display.getSupportedModes();
 		
 		float minRefreshRate = -1;
 		float maxRefreshRate = -1;
@@ -531,8 +527,6 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 		Window window = ((Activity) context).getWindow();
 		WindowManager.LayoutParams layoutParams = window.getAttributes();
 		layoutParams.preferredDisplayModeId = bestModeId;
-
-		// This is the call that needs to happen on the main thread
 		window.setAttributes(layoutParams);
 	}
 

--- a/app/os_android.go
+++ b/app/os_android.go
@@ -193,8 +193,6 @@ var gioView struct {
 	restartInput       C.jmethodID
 	updateSelection    C.jmethodID
 	updateCaret        C.jmethodID
-	countDisplayModes  C.jmethodID
-	setHighRefreshRate C.jmethodID
 }
 
 type pixelInsets struct {
@@ -482,8 +480,6 @@ func Java_org_gioui_GioView_onCreateView(env *C.JNIEnv, class C.jclass, view C.j
 		m.restartInput = getMethodID(env, class, "restartInput", "()V")
 		m.updateSelection = getMethodID(env, class, "updateSelection", "()V")
 		m.updateCaret = getMethodID(env, class, "updateCaret", "(FFFFFFFFFF)V")
-		m.countDisplayModes = getMethodID(env, class, "countDisplayModes", "()I")
-		m.setHighRefreshRate = getMethodID(env, class, "setHighRefreshRate", "()V")
 	})
 	view = C.jni_NewGlobalRef(env, view)
 	wopts := <-mainWindow.out
@@ -779,13 +775,6 @@ func (w *window) setVisible(env *C.JNIEnv) {
 	width, height := C.ANativeWindow_getWidth(w.win), C.ANativeWindow_getHeight(w.win)
 	if width == 0 || height == 0 {
 		return
-	}
-	displayModeCount := int(C.jni_CallIntMethod(env, w.view, gioView.countDisplayModes))
-	if displayModeCount > 1 {
-		// Only do the main thread work on devices that need it
-		runOnMainWithEnv(env, func(mainEnv *C.JNIEnv) {
-			callVoidMethod(mainEnv, w.view, gioView.setHighRefreshRate)
-		})
 	}
 	w.setStage(system.StageRunning)
 	w.draw(env, true)
@@ -1446,11 +1435,6 @@ func runOnMain(f func(env *C.JNIEnv)) {
 			callStaticVoidMethod(env, android.gioCls, android.mwakeupMainThread)
 		})
 	}()
-}
-
-func runOnMainWithEnv(env *C.JNIEnv, f func(mainEnv *C.JNIEnv)) {
-	mainFuncs <- f
-	callStaticVoidMethod(env, android.gioCls, android.mwakeupMainThread)
 }
 
 //export Java_org_gioui_Gio_scheduleMainFuncs


### PR DESCRIPTION
Some devices with high refresh rates limit SurfaceView apps to 60hz and need a specific API call to set it back. Same approach is used by https://github.com/ajinasokan/flutter_displaymode. The extra work is skipped on the devices that don't need it.