### PR TITLE
app:[linux,windows,wasm] Horizontal scroll with shift key pressed

### DIFF
--- a/app/os_js.go
+++ b/app/os_js.go
@@ -236,6 +236,10 @@ func (w *window) addEventListeners() {
 	w.addEventListener(w.cnv, "wheel", func(this js.Value, args []js.Value) interface{} {
 		e := args[0]
 		dx, dy := e.Get("deltaX").Float(), e.Get("deltaY").Float()
+		// horizontal scroll if shift key pressed
+		if e.Get("shiftKey").Bool() {
+			dx, dy = dy, dx
+		}
 		mode := e.Get("deltaMode").Int()
 		switch mode {
 		case 0x01: // DOM_DELTA_LINE

--- a/app/os_wayland.go
+++ b/app/os_wayland.go
@@ -953,7 +953,12 @@ func gio_onPointerAxis(data unsafe.Pointer, p *C.struct_wl_pointer, t, axis C.ui
 	case C.WL_POINTER_AXIS_HORIZONTAL_SCROLL:
 		w.scroll.dist.X += v
 	case C.WL_POINTER_AXIS_VERTICAL_SCROLL:
-		w.scroll.dist.Y += v
+		// horizontal scroll if shiftKey + mousewheel(up/down) pressed
+		if w.disp.xkb.Modifiers() == key.ModShift {
+			w.scroll.dist.X += v
+		} else {
+			w.scroll.dist.Y += v
+		}
 	}
 }
 
@@ -1003,7 +1008,12 @@ func gio_onPointerAxisDiscrete(data unsafe.Pointer, p *C.struct_wl_pointer, axis
 	case C.WL_POINTER_AXIS_HORIZONTAL_SCROLL:
 		w.scroll.steps.X += int(discrete)
 	case C.WL_POINTER_AXIS_VERTICAL_SCROLL:
-		w.scroll.steps.Y += int(discrete)
+		// horizontal scroll if shiftKey + mousewheel(up/down) pressed
+		if w.disp.xkb.Modifiers() == key.ModShift {
+			w.scroll.steps.X += int(discrete)
+		} else {
+			w.scroll.steps.Y += int(discrete)
+		}
 	}
 }
 

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -531,7 +531,12 @@ func (w *window) scrollEvent(wParam, lParam uintptr, horizontal bool, kmods key.
 	if horizontal {
 		sp.X = dist
 	} else {
-		sp.Y = -dist
+		// support horizontal scroll (shift + mousewheel)
+		if kmods == key.ModShift {
+			sp.X = -dist
+		} else {
+			sp.Y = -dist
+		}
 	}
 	w.w.Event(pointer.Event{
 		Type:      pointer.Scroll,

--- a/app/os_x11.go
+++ b/app/os_x11.go
@@ -569,13 +569,21 @@ func (h *x11EventHandler) handleEvents() bool {
 			case C.Button3:
 				btn = pointer.ButtonSecondary
 			case C.Button4:
-				// scroll up
 				ev.Type = pointer.Scroll
-				ev.Scroll.Y = -scrollScale
+				// scroll up or left(if shiftKey pressed)
+				if ev.Modifiers == key.ModShift {
+					ev.Scroll.X = -scrollScale
+				} else {
+					ev.Scroll.Y = -scrollScale
+				}
 			case C.Button5:
-				// scroll down
+				// scroll down or right(if shiftKey pressed)
 				ev.Type = pointer.Scroll
-				ev.Scroll.Y = +scrollScale
+				if ev.Modifiers == key.ModShift {
+					ev.Scroll.X = +scrollScale
+				} else {
+					ev.Scroll.Y = +scrollScale
+				}
 			case 6:
 				// http://xahlee.info/linux/linux_x11_mouse_button_number.html
 				// scroll left


### PR DESCRIPTION
Fixes: https://todo.sr.ht/~eliasnaur/gio/398

Adds support for horizontal scroll using mousewheel and shift key pressed. Support is added for windows,linux(wayland and x11),js(wasm).