### PR TITLE
io,app: add deeplinking support

### DIFF
--- a/app/GioActivity.java
+++ b/app/GioActivity.java
@@ -4,6 +4,7 @@ package org.gioui;
 
 import android.app.Activity;
 import android.os.Bundle;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.view.ViewGroup;
 import android.view.View;
@@ -29,6 +30,7 @@ public final class GioActivity extends Activity {
 
             layer.addView(view);
             setContentView(layer);
+            onNewIntent(this.getIntent());
 	}
 
 	@Override public void onDestroy() {
@@ -59,5 +61,10 @@ public final class GioActivity extends Activity {
 	@Override public void onBackPressed() {
 		if (!view.backPressed())
 			super.onBackPressed();
+	}
+
+	@Override protected void onNewIntent(Intent intent) {
+		super.onNewIntent(intent);
+        view.onIntentEvent(intent);
 	}
 }

--- a/app/GioView.java
+++ b/app/GioView.java
@@ -12,6 +12,7 @@ import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
@@ -311,6 +312,15 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 		window.setAttributes(layoutParams);
 	}
 
+	protected void onIntentEvent(Intent intent) {
+        if (intent == null) {
+            return;
+        }
+        if (intent.getData() != null) {
+            this.onDeeplink(nhandle, intent.getData().toString());
+        }
+    }
+
 	@Override protected boolean dispatchHoverEvent(MotionEvent event) {
 		if (!accessManager.isTouchExplorationEnabled()) {
 			return super.dispatchHoverEvent(event);
@@ -549,6 +559,7 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 	static private native void onExitTouchExploration(long handle);
 	static private native void onA11yFocus(long handle, int viewId);
 	static private native void onClearA11yFocus(long handle, int viewId);
+	static private native void onDeeplink(long handle, String uri);
 	static private native void imeSetSnippet(long handle, int start, int end);
 	static private native String imeSnippet(long handle);
 	static private native int imeSnippetStart(long handle);

--- a/app/framework_ios.h
+++ b/app/framework_ios.h
@@ -3,4 +3,5 @@
 #include <UIKit/UIKit.h>
 
 @interface GioViewController : UIViewController
+- (BOOL)onDeeplink:(NSString *)url;
 @end

--- a/app/internal/windows/windows.go
+++ b/app/internal/windows/windows.go
@@ -99,6 +99,8 @@ const (
 
 	CW_USEDEFAULT = -2147483648
 
+	ERROR_ALREADY_EXISTS = 183
+
 	GWL_STYLE = ^(uintptr(16) - 1) // -16
 
 	GCS_COMPSTR       = 0x0008
@@ -111,7 +113,8 @@ const (
 	CFS_POINT        = 0x0002
 	CFS_CANDIDATEPOS = 0x0040
 
-	HWND_TOPMOST = ^(uint32(1) - 1) // -1
+	HWND_TOPMOST   = ^(uint32(1) - 1) // -1
+	HWND_BROADCAST = 0xFFFF
 
 	HTCAPTION     = 2
 	HTCLIENT      = 1
@@ -303,15 +306,25 @@ const (
 	LR_MONOCHROME       = 0x00000001
 	LR_SHARED           = 0x00008000
 	LR_VGACOLOR         = 0x00000080
+
+	FILE_MAP_READ = 0x0004
+)
+
+var (
+	GIO_DEEPLINKING uint32 // Custom message for deep linking, lazy init
 )
 
 var (
 	kernel32          = syscall.NewLazySystemDLL("kernel32.dll")
+	_CreateMutex      = kernel32.NewProc("CreateMutexW")
+	_GetMutexInfo     = kernel32.NewProc("GetMutexInfo")
 	_GetModuleHandleW = kernel32.NewProc("GetModuleHandleW")
 	_GlobalAlloc      = kernel32.NewProc("GlobalAlloc")
 	_GlobalFree       = kernel32.NewProc("GlobalFree")
 	_GlobalLock       = kernel32.NewProc("GlobalLock")
 	_GlobalUnlock     = kernel32.NewProc("GlobalUnlock")
+	_OpenFileMapping  = kernel32.NewProc("OpenFileMappingA")
+	_ReleaseMutex     = kernel32.NewProc("ReleaseMutex")
 
 	user32                       = syscall.NewLazySystemDLL("user32.dll")
 	_AdjustWindowRectEx          = user32.NewProc("AdjustWindowRectEx")
@@ -347,9 +360,11 @@ var (
 	_PostQuitMessage             = user32.NewProc("PostQuitMessage")
 	_ReleaseCapture              = user32.NewProc("ReleaseCapture")
 	_RegisterClassExW            = user32.NewProc("RegisterClassExW")
+	_RegisterWindowMessage       = user32.NewProc("RegisterWindowMessageW")
 	_ReleaseDC                   = user32.NewProc("ReleaseDC")
 	_ScreenToClient              = user32.NewProc("ScreenToClient")
 	_ShowWindow                  = user32.NewProc("ShowWindow")
+	_SendMessage                 = user32.NewProc("SendMessageW")
 	_SetCapture                  = user32.NewProc("SetCapture")
 	_SetCursor                   = user32.NewProc("SetCursor")
 	_SetClipboardData            = user32.NewProc("SetClipboardData")
@@ -651,6 +666,42 @@ func GlobalUnlock(h syscall.Handle) {
 	_GlobalUnlock.Call(uintptr(h))
 }
 
+func CreateMutex(name string) (ptr syscall.Handle, alreadyExists bool, err error) {
+	r, _, err := _CreateMutex.Call(0, 0, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(name))))
+	switch err.(syscall.Errno) {
+	case 0:
+		return syscall.Handle(r), false, nil
+	case ERROR_ALREADY_EXISTS:
+		return syscall.Handle(r), true, nil
+	default:
+		return 0, false, fmt.Errorf("CreateMutex: %v", err)
+	}
+}
+
+func GetMutexInfo(h syscall.Handle) (pid, count uint32, err error) {
+	r, _, err := _GetMutexInfo.Call(uintptr(h), uintptr(unsafe.Pointer(&pid)), uintptr(unsafe.Pointer(&count)))
+	if r == 0 {
+		return 0, 0, fmt.Errorf("GetMutexInfo: %v", err)
+	}
+	return pid, count, nil
+}
+
+func OpenFileMapping(name string) (ptr syscall.Handle, err error) {
+	r, _, err := _OpenFileMapping.Call(FILE_MAP_READ, 0, uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(name))))
+	if r == 0 {
+		return 0, fmt.Errorf("OpenFileMapping: %v", err)
+	}
+	return syscall.Handle(r), nil
+}
+
+func ReleaseMutex(h uintptr) error {
+	r, _, err := _ReleaseMutex.Call(h)
+	if r == 0 {
+		return fmt.Errorf("ReleaseMutex: %v", err)
+	}
+	return nil
+}
+
 func KillTimer(hwnd syscall.Handle, nIDEvent uintptr) error {
 	r, _, err := _SetTimer.Call(uintptr(hwnd), uintptr(nIDEvent), 0, 0)
 	if r == 0 {
@@ -735,8 +786,24 @@ func RegisterClassEx(cls *WndClassEx) (uint16, error) {
 	return uint16(a), nil
 }
 
+func RegisterWindowMessage(name string) (uint32, error) {
+	r, _, err := _RegisterWindowMessage.Call(uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(name))))
+	if r == 0 {
+		return 0, fmt.Errorf("RegisterWindowMessage: %v", err)
+	}
+	return uint32(r), nil
+}
+
 func ReleaseDC(hdc syscall.Handle) {
 	_ReleaseDC.Call(uintptr(hdc))
+}
+
+func SendMessage(hwnd syscall.Handle, msg uint32, wParam, lParam uintptr) error {
+	r, _, err := _SendMessage.Call(uintptr(hwnd), uintptr(msg), wParam, lParam)
+	if r == 0 {
+		return fmt.Errorf("SendMessage failed: %v", err)
+	}
+	return nil
 }
 
 func SetForegroundWindow(hwnd syscall.Handle) {

--- a/app/os_android.go
+++ b/app/os_android.go
@@ -121,9 +121,11 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"gioui.org/io/deeplink"
 	"image"
 	"image/color"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -657,6 +659,16 @@ func Java_org_gioui_GioView_onClearA11yFocus(env *C.JNIEnv, class C.jclass, view
 	if w.semantic.focusID == w.semIDFor(virtID) {
 		w.semantic.focusID = 0
 	}
+}
+
+//export Java_org_gioui_GioView_onDeeplink
+func Java_org_gioui_GioView_onDeeplink(env *C.JNIEnv, class C.jclass, view C.jlong, uri C.jstring) {
+	w := cgo.Handle(view).Value().(*window)
+	u, err := url.Parse(goString(env, uri))
+	if err != nil {
+		return
+	}
+	w.callbacks.Event(deeplink.Event{URL: u})
 }
 
 func (w *window) initAccessibilityNodeInfo(env *C.JNIEnv, sem router.SemanticNode, off image.Point, info C.jobject) error {

--- a/app/os_ios.m
+++ b/app/os_ios.m
@@ -99,6 +99,11 @@ CGFloat _keyboardHeight;
 	_keyboardHeight = 0.0;
 	[self.view setNeedsLayout];
 }
+
+- (BOOL)onDeeplink:(NSString *)url {
+    gio_onDeeplink((__bridge CFTypeRef)url);
+    return YES;
+}
 @end
 
 static void handleTouches(int last, UIView *view, NSSet<UITouch *> *touches, UIEvent *event) {

--- a/app/os_js.go
+++ b/app/os_js.go
@@ -373,6 +373,10 @@ func (w *window) keyEvent(e js.Value, ks key.State) {
 			State:     ks,
 		}
 		w.w.Event(cmd)
+
+		if cmd.Name == key.NameTab {
+			e.Call("preventDefault")
+		}
 	}
 }
 

--- a/app/os_macos.m
+++ b/app/os_macos.m
@@ -376,6 +376,7 @@ CFTypeRef gio_createView(void) {
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
 	[NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
 	[NSApp activateIgnoringOtherApps:YES];
+
 	gio_onFinishLaunching();
 }
 - (void)applicationDidHide:(NSNotification *)aNotification {
@@ -383,6 +384,11 @@ CFTypeRef gio_createView(void) {
 }
 - (void)applicationWillUnhide:(NSNotification *)notification {
 	gio_onAppShow();
+}
+- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls {
+	for (NSURL *url in urls) {
+		gio_onDeeplink((__bridge CFTypeRef)url.absoluteString);
+	}
 }
 @end
 

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -3,9 +3,18 @@
 package app
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"gioui.org/io/deeplink"
+	syscall "golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 	"image"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -15,11 +24,8 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	syscall "golang.org/x/sys/windows"
-
 	"gioui.org/app/internal/windows"
 	"gioui.org/unit"
-	gowindows "golang.org/x/sys/windows"
 
 	"gioui.org/f32"
 	"gioui.org/io/clipboard"
@@ -109,6 +115,9 @@ func newWindow(window *callbacks, options []Option) error {
 		w.w = window
 		w.w.SetDriver(w)
 		w.w.Event(ViewEvent{HWND: uintptr(w.hwnd)})
+		if startupDeeplink != "" {
+			w.processDeeplink(startupDeeplink)
+		}
 		w.Configure(options)
 		windows.SetForegroundWindow(w.hwnd)
 		windows.SetFocus(w.hwnd)
@@ -222,6 +231,10 @@ func windowProc(hwnd syscall.Handle, msg uint32, wParam, lParam uintptr) uintptr
 	}
 
 	w := win.(*window)
+
+	if msg == windows.GIO_DEEPLINKING {
+		fmt.Println("GIO_DEEPLINK", msg, wParam, lParam)
+	}
 
 	switch msg {
 	case windows.WM_UNICHAR:
@@ -418,6 +431,29 @@ func windowProc(hwnd syscall.Handle, msg uint32, wParam, lParam uintptr) uintptr
 	case windows.WM_IME_ENDCOMPOSITION:
 		w.w.SetComposingRegion(key.Range{Start: -1, End: -1})
 		return windows.TRUE
+	case windows.GIO_DEEPLINKING:
+		if schemesDeeplink == "" {
+			return windows.DefWindowProc(hwnd, msg, wParam, lParam)
+		}
+
+		size := wParam
+		if size >= 1<<16-1 {
+			return windows.TRUE
+		}
+
+		id := hex.EncodeToString(((*[unsafe.Sizeof(int(0))]byte)(unsafe.Pointer(&lParam)))[:])
+		f, err := os.Open(filepath.Join(os.TempDir(), "gio_deeplinking-"+string(id)))
+		if err != nil {
+			return windows.TRUE
+		}
+		defer f.Close()
+
+		b := make([]byte, size)
+		if _, err := io.ReadFull(f, b); err != nil {
+			return windows.TRUE
+		}
+
+		w.processDeeplink(string(b))
 	}
 
 	return windows.DefWindowProc(hwnd, msg, wParam, lParam)
@@ -652,7 +688,7 @@ func (w *window) readClipboard() error {
 		return err
 	}
 	defer windows.GlobalUnlock(mem)
-	content := gowindows.UTF16PtrToString((*uint16)(unsafe.Pointer(ptr)))
+	content := syscall.UTF16PtrToString((*uint16)(unsafe.Pointer(ptr)))
 	w.w.Event(clipboard.Event{Text: content})
 	return nil
 }
@@ -733,7 +769,7 @@ func (w *window) writeClipboard(s string) error {
 	if err := windows.EmptyClipboard(); err != nil {
 		return err
 	}
-	u16, err := gowindows.UTF16FromString(s)
+	u16, err := syscall.UTF16FromString(s)
 	if err != nil {
 		return err
 	}
@@ -850,6 +886,29 @@ func (w *window) raise() {
 		windows.SWP_NOMOVE|windows.SWP_NOSIZE|windows.SWP_SHOWWINDOW)
 }
 
+func (w *window) processDeeplink(uri string) {
+	fmt.Println("processDeeplink", uri)
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return
+	}
+
+	found := false
+	for _, scheme := range schemesDeeplinkList {
+		if u.Scheme == scheme {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return
+	}
+
+	w.w.Event(deeplink.Event{URL: u})
+}
+
 func convertKeyCode(code uintptr) (string, bool) {
 	if '0' <= code && code <= '9' || 'A' <= code && code <= 'Z' {
 		return string(rune(code)), true
@@ -952,6 +1011,134 @@ func configForDPI(dpi int) unit.Metric {
 		PxPerDp: ppdp,
 		PxPerSp: ppdp,
 	}
+}
+
+// schemesDeeplink is a list of schemes, comma separated, that most be
+// defined using -X compiler ldflag.
+var schemesDeeplink string
+var schemesDeeplinkList []string
+var startupDeeplink string
+
+func init() {
+	if schemesDeeplink == "" {
+		return
+	}
+	schemesDeeplinkList = strings.Split(schemesDeeplink, ",")
+
+	number, err := windows.RegisterWindowMessage(schemesDeeplink)
+	if err != nil {
+		return
+	}
+	windows.GIO_DEEPLINKING = number
+
+	/*
+		On Windows, launching the app using a deeplink will start a new instance of the app,
+		a new window. That behavior doesn't align with iOS/Android/macOS, where the deeplink
+		sends the event to the running app (if any).
+
+		In order to align the behavior, we use a global mutex to check if the app is already
+		running. If it is, we send the deeplink to the running app and exit the new instance.
+
+		That should happen on init to prevent the user from seeing the new window.
+	*/
+	if ok := processDeeplink(); ok {
+		os.Exit(0)
+		return
+	}
+
+	for _, scheme := range schemesDeeplinkList {
+		go registerDeeplink(scheme)
+	}
+}
+
+func registerDeeplink(scheme string) error {
+	path, err := os.Executable()
+	if err != nil {
+		return err
+	}
+
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, `Software\\Classes\\`+scheme, registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+	defer key.Close()
+
+	if err = key.SetStringValue("", "URL:"+scheme+" Protocol"); err != nil {
+		return err
+	}
+
+	if err = key.SetStringValue("URL Protocol", ""); err != nil {
+		return err
+	}
+
+	icon, _, err := registry.CreateKey(key, `DefaultIcon`, registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+	defer icon.Close()
+
+	if err = icon.SetStringValue("", `"`+path+`",1`); err != nil {
+		return err
+	}
+
+	cmd, _, err := registry.CreateKey(key, `shell\\open\\command`, registry.ALL_ACCESS)
+	if err != nil {
+		return err
+	}
+	defer cmd.Close()
+
+	// The app will launch with `-gio_deeplinking` as the first argument, and the deeplink as the second.
+	if err = cmd.SetStringValue("", `"`+path+`" -gio_deeplinking "%1"`); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processDeeplink() (finishProcess bool) {
+	_, alreadyExists, err := windows.CreateMutex(schemesDeeplink)
+	if err != nil {
+		return false
+	}
+
+	if len(os.Args) < 3 || os.Args[1] != "-gio_deeplinking" {
+		// Only one instance of the app can run at a time.
+		// If the current instance doesn't have any deeplink to process, then
+		// it will exit if another instance is already running, or it will
+		// continue if it is the first instance.
+		return alreadyExists
+	}
+
+	u := os.Args[2]
+
+	if !alreadyExists {
+		// The mutex was created by this process, and we are the first instance.
+		startupDeeplink = u
+		return alreadyExists
+	}
+
+	id := make([]byte, unsafe.Sizeof(int(0)))
+	rand.Read(id)
+
+	// First, I tried to use mmap, but that plagues everything with unsafe pointers, and it's not worth it.
+	f, err := os.Create(filepath.Join(os.TempDir(), "gio_deeplinking-"+hex.EncodeToString(id)))
+	if err != nil {
+		return alreadyExists
+	}
+
+	if _, err := f.Write([]byte(u)); err != nil {
+		return alreadyExists
+	}
+
+	if err := f.Close(); err != nil {
+		return alreadyExists
+	}
+
+	if err := windows.SendMessage(windows.HWND_BROADCAST, windows.GIO_DEEPLINKING, uintptr(len(u)), *(*uintptr)(unsafe.Pointer(&id[0]))); err != nil {
+		return alreadyExists
+	}
+
+	return alreadyExists
 }
 
 func (_ ViewEvent) ImplementsEvent() {}

--- a/app/window.go
+++ b/app/window.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"gioui.org/io/deeplink"
 	"image"
 	"image/color"
 	"runtime"
@@ -894,6 +895,8 @@ func (w *Window) processEvent(d driver, e event.Event) bool {
 	case ConfigEvent:
 		w.decorations.Config = e2.Config
 		e2.Config = w.effectiveConfig()
+		w.out <- e2
+	case deeplink.Event:
 		w.out <- e2
 	case event.Event:
 		handled := w.queue.q.Queue(e2)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	golang.org/x/exp v0.0.0-20221012211006-4de253d81b95
 	golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/image v0.5.0
-	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64
+	golang.org/x/sys v0.10.0
 )
 
 require golang.org/x/text v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/io/deeplink/deeplink.go
+++ b/io/deeplink/deeplink.go
@@ -1,0 +1,12 @@
+package deeplink
+
+import (
+	"net/url"
+)
+
+// Event is generated when the app is opened from a deeplink, or when the app is already running and a deeplink is opened.
+type Event struct {
+	URL *url.URL
+}
+
+func (Event) ImplementsEvent() {}

--- a/widget/editor.go
+++ b/widget/editor.go
@@ -319,6 +319,9 @@ func (e *Editor) processKey(gtx layout.Context) {
 		switch ke := ke.(type) {
 		case key.FocusEvent:
 			e.focused = ke.Focus
+			if e.focused {
+				key.SoftKeyboardOp{Show: true}.Add(gtx.Ops)
+			}
 			// Reset IME state.
 			e.ime.imeState = imeState{}
 		case key.Event:


### PR DESCRIPTION
Now, it's possible to launch one Gio app using a custom URI scheme, such as `gio://some/data`.

This feature is supported on Android, iOS, macOS and Windows, issuing a new deeplink.Event,
containing the URL launched. If the program is already opened, one deeplink.Event will be
sent to the current opened app.

Limitations:
On Windows, if the program uses deeplink (compiled with `-deeplink`), then just a single
instance of the app can be open. In other words, just a single `myprogram.exe` can
be active.

Security:
Deeplinking have the same level of security of clipboard. Any other software can send such
information and read the content, without any restriction. That should not be used to transfer
sensible data, and can't be fully trusted.

Setup/Compiling:
In order to set the custom scheme, you need to use the new `-deeplink` flag in `gogio`, using
as `-deeplink gio` will listen to `gio://`.

If you are not using gogio you need to defined some values, which varies for each OS:

macOS/iOS - You need to define the following Properly List:
```
<key>CFBundleURLTypes</key>
<array>
  <dict>
	<key>CFBundleURLSchemes</key>
	<array>
	  <string>yourCustomScheme</string>
	</array>
  </dict>
</array>
```

Windows - You need to compiling using -X argument:
```
-ldflags="-X "gioui.org/app.schemesDeeplink=yourCustomScheme" -H=windowsgui"
```

Android - You need to add IntentFilter in GioActivity:
```
<intent-filter>
	<action android:name="android.intent.action.VIEW"></action>
	<category android:name="android.intent.category.DEFAULT"></category>
	<category android:name="android.intent.category.BROWSABLE"></category>
	<data android:scheme="yourCustomScheme"></data>
</intent-filter>
```

That assumes that you still using GioActivity and GioAppDelegate, otherwise more
changes are required.