### PR TITLE
text: change line ascent and descent to fit font size

### DIFF
--- a/text/gotext.go
+++ b/text/gotext.go
@@ -895,11 +895,18 @@ func toLine(faceToIndex map[font.Font]int, o shaping.Line, dir system.TextDirect
 		}
 		line.runeCount += run.Runes.Count
 		line.width += run.Advance
-		if line.ascent < run.LineBounds.Ascent {
-			line.ascent = run.LineBounds.Ascent
+
+		// fix ascent to make all glyphes (CJK or not) always in same baseline
+		// fixedDescent + fixedAscent should equal fontSize
+		scale := fixedToFloat(run.Size) / fixedToFloat(run.LineBounds.LineHeight())
+		fixedAscent := floatToFixed(fixedToFloat(run.LineBounds.Ascent) * scale)
+		fixedDescent := floatToFixed(fixedToFloat(-run.LineBounds.Descent+run.LineBounds.Gap) * scale)
+
+		if line.ascent < fixedAscent {
+			line.ascent = fixedAscent
 		}
-		if line.descent < -run.LineBounds.Descent+run.LineBounds.Gap {
-			line.descent = -run.LineBounds.Descent + run.LineBounds.Gap
+		if line.descent < fixedDescent {
+			line.descent = fixedDescent
 		}
 	}
 	line.lineHeight = maxSize

--- a/text/gotext_test.go
+++ b/text/gotext_test.go
@@ -52,11 +52,41 @@ func TestEmptyString(t *testing.T) {
 		t.Fatalf("Layout returned no lines for empty string; expected 1")
 	}
 	l := lines.lines[0]
-	if expected := fixed.Int26_6(12094); l.ascent != expected {
+	if expected := fixed.Int26_6(10463); l.ascent != expected {
 		t.Errorf("unexpected ascent for empty string: %v, expected %v", l.ascent, expected)
 	}
-	if expected := fixed.Int26_6(2700); l.descent != expected {
+	if expected := fixed.Int26_6(2336); l.descent != expected {
 		t.Errorf("unexpected descent for empty string: %v, expected %v", l.descent, expected)
+	}
+}
+
+func TestCJKOrNotString(t *testing.T) {
+	ppem := fixed.I(200)
+	ltrFace, _ := opentype.Parse(goregular.TTF)
+	shaper := testShaper(ltrFace)
+
+	for _, r := range [][]rune{
+		[]rune("Sa"),
+		[]rune("SayHi"),
+		[]rune("SayHi 您好"),
+		[]rune("✨ⷽℎ↞⋇ⱜ⪫⢡⽛⣦␆Ⱨⳏ⳯⒛⭣╎⌞⟻⢇┃➡⬎⩱⸇ⷎ⟅▤⼶⇺⩳⎏⤬⬞ⴈ⋠⿶⢒₍☟⽂ⶦ⫰⭢⌹∼▀⾯⧂❽⩏ⓖ⟅⤔⍇␋⽓ₑ⢳⠑❂⊪⢘⽨⃯▴ⷿ"),
+	} {
+		t.Run("ascent/descent should fit font size", func(t *testing.T) {
+			lines := shaper.LayoutRunes(Parameters{
+				PxPerEm:  ppem,
+				MaxWidth: 2000,
+				Locale:   english,
+			}, r)
+
+			l := lines.lines[0]
+
+			if expected := fixed.Int26_6(10463); l.ascent != expected {
+				t.Errorf("unexpected ascent for string: %v, expected %v", l.ascent, expected)
+			}
+			if expected := fixed.Int26_6(2336); l.descent != expected {
+				t.Errorf("unexpected descent for empty string: %v, expected %v", l.descent, expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
With this patch, the example will render correct like

<img width="1005" alt="image" src="https://github.com/gioui/gio/assets/1667873/a90afd43-bac3-4560-9045-7d782fabd1f0">

with v0.3.0，same font size and line height not stacked.

<img width="1001" alt="image" src="https://github.com/gioui/gio/assets/1667873/fccb1d5f-000d-4f29-b7b7-4c44c01c1823">

For `widget.Editor`, 
baseline will change, when CJK char input after nonCJK ones.
This patch could fix this too.

Example:

```go
package main

import (
	"image/color"
	"log"
	"os"

	"gioui.org/app"
	"gioui.org/font"
	"gioui.org/io/system"
	"gioui.org/layout"
	"gioui.org/op"
	"gioui.org/op/paint"
	"gioui.org/text"
	"gioui.org/unit"
	"gioui.org/widget"
	"gioui.org/widget/material"
	"gioui.org/x/richtext"

	"gioui.org/font/gofont"
)

var textSize = unit.Sp(100)
var lineHeight = textSize * 3

func main() {
	th := NewTheme(gofont.Collection())

	ui := UI{
		Theme:  th,
		Window: app.NewWindow(app.Size(1000, unit.Dp(lineHeight))),
	}

	go func() {
		if err := ui.Loop(); err != nil {
			log.Fatal(err)
		}
		os.Exit(0)
	}()
	app.Main()
}

type (
	C = layout.Context
	D = layout.Dimensions
)

// UI specifies the user interface.
type UI struct {
	Theme  *Theme
	Window *app.Window
	Editor *widget.Editor
}

// Theme contains semantic style data.
type Theme struct {
	// Base theme to extend.
	Base *material.Theme
	// cache of processed markdown.
	cache []richtext.SpanStyle
}

func NewTheme(font []font.FontFace) *Theme {
	th := material.NewTheme()
	th.Shaper = text.NewShaper(text.WithCollection(font))
	return &Theme{
		Base: th,
	}
}

func (ui UI) Loop() error {
	var ops op.Ops
	for e := range ui.Window.Events() {
		switch e := e.(type) {
		case system.DestroyEvent:
			return e.Err
		case system.FrameEvent:
			gtx := layout.NewContext(&ops, e)
			ui.Layout(gtx)
			e.Frame(gtx.Ops)
		}
	}
	return nil
}

func (ui *UI) Layout(gtx C) D {
	if ui.Editor == nil {
		ui.Editor = &widget.Editor{}
	}

	ui.Theme.Base.TextSize = textSize

	ui.Editor.LineHeight = lineHeight
	ui.Editor.LineHeightScale = 1
	ui.Editor.SingleLine = true

	return layout.Stack{}.Layout(gtx,
		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
			l := widget.Label{}

			l.LineHeight = ui.Editor.LineHeight
			l.LineHeightScale = ui.Editor.LineHeightScale

			m := op.Record(gtx.Ops)
			paint.ColorOp{Color: color.NRGBA{R: 0xff, A: 0x30}}.Add(gtx.Ops)
			call := m.Stop()

			return l.Layout(
				gtx,
				ui.Theme.Base.Shaper,
				font.Font{
					Typeface: ui.Theme.Base.Face,
				},
				ui.Theme.Base.TextSize,
				"SayHi 你好",
				call,
			)
		}),
		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
			l := widget.Label{}

			l.LineHeight = ui.Editor.LineHeight
			l.LineHeightScale = ui.Editor.LineHeightScale

			m := op.Record(gtx.Ops)
			paint.ColorOp{Color: color.NRGBA{B: 0xff, A: 0x30}}.Add(gtx.Ops)
			call := m.Stop()

			return l.Layout(
				gtx,
				ui.Theme.Base.Shaper,
				font.Font{
					Typeface: ui.Theme.Base.Face,
				},
				ui.Theme.Base.TextSize,
				"SayHi",
				call,
			)
		}),
		layout.Expanded(func(gtx layout.Context) layout.Dimensions {
			m := op.Record(gtx.Ops)
			paint.ColorOp{Color: color.NRGBA{G: 0xff, A: 0x30}}.Add(gtx.Ops)
			call := m.Stop()

			if ui.Editor.Text() == "" {
				ui.Editor.SetText("Sa")
			}

			dims := ui.Editor.Layout(
				gtx,
				ui.Theme.Base.Shaper,
				font.Font{
					Typeface: ui.Theme.Base.Face,
				},
				ui.Theme.Base.TextSize,
				call,
				op.CallOp{},
			)

			return dims
		}),
	)
}
```