### PR TITLE
text: fix run offset

### DIFF
--- a/text/shaper.go
+++ b/text/shaper.go
@@ -458,7 +458,13 @@ func (l *Shaper) NextGlyph() (_ Glyph, ok bool) {
 			l.advance += g.xAdvance
 		}
 		// runOffset computes how far into the run the dot should be positioned.
-		runOffset := l.advance
+		//
+		// xOffset will change when letter after different letter
+		// example: "Tool"
+		//  	the first  o with -1 xOffset
+		//  	the second o with  0 xOffset
+		// and the glyph boxes are overlapping, because of the xOffset
+		runOffset := l.advance + g.xOffset
 		if rtl {
 			runOffset = run.Advance - l.advance
 		}


### PR DESCRIPTION
xOffset will change when letter after different letter
example: "Tooltip" 
* the first  o with -1 xOffset
* the second o with  0 xOffset


the glyph boxes are overlapping, when the negative xOffset exists. like, The `T` box and `o` box.
<img width="88" alt="image" src="https://github.com/gioui/gio/assets/1667873/02855c00-8c6d-4837-b9d0-1e0683b49f11">

Without this patch, the double `o` is so closed, without overlapping
![image](https://github.com/gioui/gio/assets/1667873/a1a74067-13e4-40b3-8703-f1f78d5a445a)

