### PR TITLE
app: raiseWindow on macos should activate the app if not active

### DIFF
--- a/app/os_macos.go
+++ b/app/os_macos.go
@@ -192,6 +192,10 @@ static CFTypeRef windowForView(CFTypeRef viewRef) {
 }
 
 static void raiseWindow(CFTypeRef windowRef) {
+	NSRunningApplication *currentApp = [NSRunningApplication currentApplication];
+	if (![currentApp isActive]) {
+		[currentApp activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
+	}
 	NSWindow* window = (__bridge NSWindow *)windowRef;
 	[window makeKeyAndOrderFront:nil];
 }


### PR DESCRIPTION
Calling window.Perform(system.ActionRaise) does not show the window on the top if the app is currently not active. This can happen for example, if the app integrated with systray (https://pkg.go.dev/fyne.io/systray) where the menu item launches a window, the window is not showing at the top. It is fixed by activating the current app if necessary