### PR TITLE
material: fix documentation

### DIFF
--- a/widget/material/doc.go
+++ b/widget/material/doc.go
@@ -36,7 +36,7 @@
 // Theme-global parameters: For changing the look of all widgets drawn with a
 // particular theme, adjust the `Theme` fields:
 //
-//	theme.Color.Primary = color.NRGBA{...}
+//	theme.Palette.Fg = color.NRGBA{...}
 //
 // Widget-local parameters: For changing the look of a particular widget,
 // adjust the widget specific theme object:

--- a/widget/material/doc.go
+++ b/widget/material/doc.go
@@ -49,7 +49,7 @@
 // though the underlying state is the same. A widget.Clickable can be drawn as a
 // round icon button:
 //
-//	icon := material.NewIcon(...)
+//	icon := widget.NewIcon(...)
 //
 //	material.IconButton(theme, icon).Layout(gtx, button)
 //


### PR DESCRIPTION
It looks like the documentation for setting theme colours is out of sync with the implementation, so I've changed it to say what I think it should say, but I am very new to Gio so I could conceivably have misunderstood something.