### PR TITLE
material: fix documentation of using buttons

### DIFF
--- a/widget/material/doc.go
+++ b/widget/material/doc.go
@@ -22,7 +22,7 @@
 //
 //	theme := material.NewTheme(...)
 //
-//	material.Button(theme, "Click me!").Layout(gtx, button)
+//	material.Button(theme, button, "Click me!").Layout(gtx)
 //
 // # Customization
 //
@@ -41,9 +41,9 @@
 // Widget-local parameters: For changing the look of a particular widget,
 // adjust the widget specific theme object:
 //
-//	btn := material.Button(theme, "Click me!")
+//	btn := material.Button(theme, button, "Click me!")
 //	btn.Font.Style = text.Italic
-//	btn.Layout(gtx, button)
+//	btn.Layout(gtx)
 //
 // Widget variants: A widget can have several distinct representations even
 // though the underlying state is the same. A widget.Clickable can be drawn as a
@@ -51,7 +51,7 @@
 //
 //	icon := widget.NewIcon(...)
 //
-//	material.IconButton(theme, icon).Layout(gtx, button)
+//	material.IconButton(theme, button, icon, "Click me!").Layout(gtx)
 //
 // Specialized widgets: Theme both define a generic Label method
 // that takes a text size, and specialized methods for standard text


### PR DESCRIPTION
The material `Button` and `IconButton` take the `*widget.Clickable` as an argument to the constructor, instead of an argument to `Layout()`, so I've updated the documentation accordingly.

Also `IconButton()` takes a description string, so I added one, I chose `"Click me!"` for consistency with the other example, but maybe something else is more appropriate.