### PR TITLE
io,layout: switch Source from struct to interface

### DIFF
--- a/layout/context.go
+++ b/layout/context.go
@@ -45,6 +45,6 @@ func (c Context) Sp(v unit.Sp) int {
 // Disabled returns a copy of this context with a disabled Source,
 // blocking widgets from changing its state and receiving events.
 func (c Context) Disabled() Context {
-	c.Source = input.Source{}
+	c.Source = input.NewDisabledSource()
 	return c
 }


### PR DESCRIPTION
I'm migrating from version 0.1 to 0.6, and I'm also migrating `gio-plugins` and other packages. However, the lack of interfaces makes it harder to intercept and add custom events into the `layout.Context`.

**Background:** In previous versions, `Queue` was an interface. This allowed for custom implementations, a feature that `gio-plugins` relies on. It was possible (even if not explicitly intended) to use:

```go
gtx.Events(tag) // returning custom event

gioexplorer.OpenFileOp{Tag: p.tag, Mimetype: FileTypes}.Add(gtx.Ops) // add custom event to Ops
```

That Op was captured by a custom implementation of Queue. The same implementation was responsible for injecting another custom event, such as gioexplorer.OpenFileEvent.

----------

Currently, in version 0.6, it's not possible to achieve the same results. It is impossible to gtx.Execute(gioexplorer.OpenFile{}) and then catch a transfer.DataEvent{}.

Alternatives and Failed Attempts:

1. go:linkname: Using go:linkname is impossible due to the inlining of Source.Execute and Source.Event. The only option would be using //go:noinline in the Gio source code, which requires changes anyway.

2. go -overlay: This command allows replacing files and supposedly changing the current router.go. However, it is harder to use (requires generator + compilation arguments) and is currently incompatible with gogio.

3. External events: The point of gio-plugins was to be similar to Gio, allowing for similar usage across components. While calling gioexplorer.Open() and gtx.Execute(gioexplorer.Open{}) is not much different, we need to get the result. Using the current gtx.Event helps to streamline everything. Otherwise, you need to keep some callback function, channel, or spawn goroutines.

---------

Switching from Struct to Interface fixes this issue, and it's the cleaner solution. It may have some performance impact, due to dynamic-dispatch. The current code also caches the `source` as `Source` to prevent mitigate allocations. Furthermore, the `disabled` use the same Source, instead of creating new ones.