### PR TITLE
app: add support to hidden minimize and maximize buttons on macos and …

### DIFF
--- a/app/os.go
+++ b/app/os.go
@@ -45,6 +45,12 @@ type Config struct {
 	CustomRenderer bool
 	// Decorated reports whether window decorations are provided automatically.
 	Decorated bool
+
+	// MinimizeButtonHidden hide the window's minimize button (only works for windows and macOS)
+	MinimizeButtonHidden bool
+	// MaximizeButtonHidden hide the window's maximize button (only works for windows and macOS)
+	MaximizeButtonHidden bool
+
 	// Focused reports whether has the keyboard focus.
 	Focused bool
 	// decoHeight is the height of the fallback decoration for platforms such

--- a/app/os_macos.go
+++ b/app/os_macos.go
@@ -495,8 +495,11 @@ func (w *window) Configure(options []Option) {
 	C.setWindowTitleVisibility(window, titleVis)
 	C.setWindowStyleMask(window, mask)
 	C.setWindowStandardButtonHidden(window, C.NSWindowCloseButton, barTrans)
-	C.setWindowStandardButtonHidden(window, C.NSWindowMiniaturizeButton, barTrans)
-	C.setWindowStandardButtonHidden(window, C.NSWindowZoomButton, barTrans)
+	// no decorated or hide minimize and maximize buttons
+	w.config.MinimizeButtonHidden = cnf.MinimizeButtonHidden
+	w.config.MaximizeButtonHidden = cnf.MaximizeButtonHidden
+	C.setWindowStandardButtonHidden(window, C.NSWindowMiniaturizeButton, toInt(!cnf.Decorated || cnf.MinimizeButtonHidden))
+	C.setWindowStandardButtonHidden(window, C.NSWindowZoomButton, toInt(!cnf.Decorated || cnf.MaximizeButtonHidden))
 	// When toggling the titlebar, the layer doesn't update its frame
 	// until the next resize. Force it.
 	C.resetLayerFrame(w.view)
@@ -1159,6 +1162,14 @@ func convertMods(mods C.NSUInteger) key.Modifiers {
 		kmods |= key.ModShift
 	}
 	return kmods
+}
+
+// toInt golang bool to C.int
+func toInt(v bool) C.int {
+	if v {
+		return C.int(C.YES)
+	}
+	return C.int(C.NO)
 }
 
 func (AppKitViewEvent) implementsViewEvent() {}

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -710,6 +710,8 @@ func (w *window) Configure(options []Option) {
 	w.config.Decorated = cnf.Decorated
 	w.config.MinSize = cnf.MinSize
 	w.config.MaxSize = cnf.MaxSize
+	w.config.MinimizeButtonHidden = cnf.MinimizeButtonHidden
+	w.config.MaximizeButtonHidden = cnf.MaximizeButtonHidden
 	windows.SetWindowText(w.hwnd, cnf.Title)
 
 	style := windows.GetWindowLong(w.hwnd, windows.GWL_STYLE)
@@ -771,7 +773,9 @@ func (w *window) Configure(options []Option) {
 
 	// Disable maximize button if MaxSize is set.
 	if cnf.MaxSize != (image.Point{X: 0, Y: 0}) {
-		style &^= windows.WS_MAXIMIZEBOX
+		// On Windows, clicking maximize button will maximize the window to its' max size, so we don't hide the button.
+		// style &^= windows.WS_MAXIMIZEBOX
+
 		// Disable window resizing if MinSize and MaxSize are equal.
 		if cnf.MinSize == cnf.MaxSize {
 			style &^= windows.WS_THICKFRAME

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -772,14 +772,8 @@ func (w *window) Configure(options []Option) {
 	}
 
 	// Disable maximize button if MaxSize is set.
-	if cnf.MaxSize != (image.Point{X: 0, Y: 0}) {
-		// On Windows, clicking maximize button will maximize the window to its' max size, so we don't hide the button.
-		// style &^= windows.WS_MAXIMIZEBOX
-
-		// Disable window resizing if MinSize and MaxSize are equal.
-		if cnf.MinSize == cnf.MaxSize {
-			style &^= windows.WS_THICKFRAME
-		}
+	if cnf.MaxSize != (image.Point{X: 0, Y: 0}) && cnf.MinSize == cnf.MaxSize {
+		style &^= windows.WS_THICKFRAME
 	}
 
 	// Note: these invocation all trigger the windows callback method which may process a pending system.ActionCenter

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -758,6 +758,16 @@ func (w *window) Configure(options []Option) {
 		swpStyle |= windows.SWP_NOMOVE | windows.SWP_NOSIZE
 		showMode = windows.SW_SHOWMAXIMIZED
 	}
+	if w.config.MinimizeButtonHidden {
+		style &^= windows.WS_MINIMIZEBOX
+	} else {
+		style |= windows.WS_MINIMIZEBOX
+	}
+	if w.config.MaximizeButtonHidden {
+		style &^= windows.WS_MAXIMIZEBOX
+	} else {
+		style |= windows.WS_MAXIMIZEBOX
+	}
 
 	// Disable maximize button if MaxSize is set.
 	if cnf.MaxSize != (image.Point{X: 0, Y: 0}) {

--- a/app/window.go
+++ b/app/window.go
@@ -969,6 +969,24 @@ func Decorated(enabled bool) Option {
 	}
 }
 
+// MinimizeButtonHidden hides the minimize button of the window.
+//
+// MinimizeButtonHidden is supported on Windows and macOS.
+func MinimizeButtonHidden(hidden bool) Option {
+	return func(_ unit.Metric, cnf *Config) {
+		cnf.MinimizeButtonHidden = hidden
+	}
+}
+
+// MaximizeButtonHidden hides the maximize button of the window.
+//
+// MaximizeButtonHidden is supported on Windows and macOS.
+func MaximizeButtonHidden(hidden bool) Option {
+	return func(_ unit.Metric, cnf *Config) {
+		cnf.MaximizeButtonHidden = hidden
+	}
+}
+
 // flushEvent is sent to detect when the user program
 // has completed processing of all prior events. Its an
 // [io/event.Event] but only for internal use.


### PR DESCRIPTION
Two options `app.HiddenMinimizeButton` and `app.HiddenMaximizeButton` are added to create a window without minimize or/and maximize buttons.

## hide both minimize and maximize buttons
```
w := new(app.Window)
w.Option(app.HiddenMinimizeButton(true), app.HiddenMaximizeButton(true))
```
<img width="141" alt="image" src="https://github.com/user-attachments/assets/ef75ec0c-9faa-4d27-8ae1-84b84da70412">

## hide minimize button, keep maximize button:
```
w := new(app.Window)
w.Option(app.HiddenMinimizeButton(true), app.HiddenMaximizeButton(false))
```
- on macOS:
<img width="111" alt="image" src="https://github.com/user-attachments/assets/44e08fae-b709-42f1-8be7-3cd403d245d8">

- on Windows:
<img width="136" alt="image" src="https://github.com/user-attachments/assets/660c9822-5594-4f66-88b9-cd0baf7a3a82">
