### PR TITLE
app: [android] fix compatibility with older Android versions

### DIFF
--- a/app/GioView.java
+++ b/app/GioView.java
@@ -259,6 +259,10 @@ public final class GioView extends SurfaceView implements Choreographer.FrameCal
 	}
 
 	private void setHighRefreshRate() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+			return;
+		}
+
 		Context context = getContext();
 		Display display = context.getDisplay();
 		Display.Mode[] supportedModes = display.getSupportedModes();


### PR DESCRIPTION
Previously, setHighRefreshRate requires APIs restricted to Android 30, or higher.

Tested on Android 6.0.1 (released on 2015).