### PR TITLE
app: [Windows] correctly center window on startup

### DIFF
--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -760,8 +760,10 @@ func (w *window) Configure(options []Option) {
 		}
 	}
 
-	windows.SetWindowLong(w.hwnd, windows.GWL_STYLE, style)
+	// Note: these invocation all trigger the windows callback method which may process a pending system.ActionCenter
+	// action, so SetWindowPos should come first so as to not "overwrite" system.ActionCenter.
 	windows.SetWindowPos(w.hwnd, 0, x, y, width, height, swpStyle)
+	windows.SetWindowLong(w.hwnd, windows.GWL_STYLE, style)
 	windows.ShowWindow(w.hwnd, showMode)
 }
 


### PR DESCRIPTION
When the window is created position it *before* processing the actions to perform (which may include system.ActionCenter). Note that the actions are performed in the callback windowProc().

Fixes: https://todo.sr.ht/~eliasnaur/gio/646