### PR TITLE
layout: add option to handle vertial scroll on horizontal list

### DIFF
--- a/gesture/gesture.go
+++ b/gesture/gesture.go
@@ -322,6 +322,8 @@ func (s *Scroll) Update(cfg unit.Metric, q input.Source, t time.Time, axis Axis,
 				s.scroll += e.Scroll.X
 			case Vertical:
 				s.scroll += e.Scroll.Y
+			case Both:
+				s.scroll += e.Scroll.X + e.Scroll.Y
 			}
 			iscroll := int(s.scroll)
 			s.scroll -= float32(iscroll)
@@ -353,10 +355,15 @@ func (s *Scroll) Update(cfg unit.Metric, q input.Source, t time.Time, axis Axis,
 }
 
 func (s *Scroll) val(axis Axis, p f32.Point) float32 {
-	if axis == Horizontal {
+	switch axis {
+	case Horizontal:
 		return p.X
-	} else {
+	case Vertical:
 		return p.Y
+	case Both:
+		return p.X + p.Y
+	default:
+		return 0
 	}
 }
 

--- a/layout/list.go
+++ b/layout/list.go
@@ -29,6 +29,8 @@ type List struct {
 	ScrollToEnd bool
 	// Alignment is the cross axis alignment of list elements.
 	Alignment Alignment
+	// ScrollAnyAxis allows any scroll axis to scroll the list, not just the main axis.
+	ScrollAnyAxis bool
 
 	cs          Constraints
 	scroll      gesture.Scroll
@@ -159,12 +161,19 @@ func (l *List) update(gtx Context) {
 			max = 0
 		}
 	}
+
 	xrange := pointer.ScrollRange{Min: min, Max: max}
 	yrange := pointer.ScrollRange{}
-	if l.Axis == Vertical {
+
+	axis := gesture.Axis(l.Axis)
+	if l.ScrollAnyAxis {
+		axis = gesture.Both
+		yrange = xrange
+	} else if l.Axis == Vertical {
 		xrange, yrange = yrange, xrange
 	}
-	d := l.scroll.Update(gtx.Metric, gtx.Source, gtx.Now, gesture.Axis(l.Axis), xrange, yrange)
+	d := l.scroll.Update(gtx.Metric, gtx.Source, gtx.Now, axis, xrange, yrange)
+
 	l.scrollDelta = d
 	l.Position.Offset += d
 }


### PR DESCRIPTION
Previously, it was impossible to scroll a Axis == Horizontal using ordinary mouse-wheel. Now, it's possible to set ScrollAnyAxis == True, which combine scrolling from any direction. That makes possible to scroll Horizontal lists with vertical mouse-wheel.

By default this option is False, keeping the old behaviour.