### PR TITLE
internal/debug: go 1.23.8 compat; use strings.Split not strings.SplitSeq

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -34,7 +34,7 @@ func Parse() {
 		}
 		print := false
 		silent := false
-		for part := range strings.SplitSeq(val, ",") {
+		for _, part := range strings.Split(val, ",") {
 			switch part {
 			case textSubsystem:
 				Text.Store(true)


### PR DESCRIPTION
Currently build fails as go.mod uses go 1.23.8 which doesn't have strings.SplitSeq. 

Note: strings.SplitSeq was introduced in go 1.24.