### PR TITLE
[text] bump go-text version and use new API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	eliasnaur.com/font v0.0.0-20230308162249-dd43949cb42d
 	gioui.org/shader v1.0.8
-	github.com/go-text/typesetting v0.3.0
+	github.com/go-text/typesetting v0.3.4-0.20260212223459-61132395d55c
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/exp/shiny v0.0.0-20250408133849-7e4ce0ab07d0
 	golang.org/x/image v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,10 @@ eliasnaur.com/font v0.0.0-20230308162249-dd43949cb42d/go.mod h1:OYVuxibdk9OSLX8v
 gioui.org/cpu v0.0.0-20210808092351-bfe733dd3334/go.mod h1:A8M0Cn5o+vY5LTMlnRoK3O5kG+rH0kWfJjeKd9QpBmQ=
 gioui.org/shader v1.0.8 h1:6ks0o/A+b0ne7RzEqRZK5f4Gboz2CfG+mVliciy6+qA=
 gioui.org/shader v1.0.8/go.mod h1:mWdiME581d/kV7/iEhLmUgUK5iZ09XR5XpduXzbePVM=
-github.com/go-text/typesetting v0.3.0 h1:OWCgYpp8njoxSRpwrdd1bQOxdjOXDj9Rqart9ML4iF4=
-github.com/go-text/typesetting v0.3.0/go.mod h1:qjZLkhRgOEYMhU9eHBr3AR4sfnGJvOXNLt8yRAySFuY=
-github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
-github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting v0.3.4-0.20260212223459-61132395d55c h1:vjm3Oi9YCM9BYa8yeBoln7YdqCGivuCjvmaYkHE0sr0=
+github.com/go-text/typesetting v0.3.4-0.20260212223459-61132395d55c/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/exp/shiny v0.0.0-20250408133849-7e4ce0ab07d0 h1:tMSqXTK+AQdW3LpCbfatHSRPHeW6+2WuxaVQuHftn80=

--- a/text/gotext_test.go
+++ b/text/gotext_test.go
@@ -209,39 +209,6 @@ func TestNewlineSynthesis(t *testing.T) {
 	}
 }
 
-// simpleGlyph returns a simple square glyph with the provided cluster
-// value.
-func simpleGlyph(cluster int) shaping.Glyph {
-	return complexGlyph(cluster, 1, 1)
-}
-
-// ligatureGlyph returns a simple square glyph with the provided cluster
-// value and number of runes.
-func ligatureGlyph(cluster, runes int) shaping.Glyph {
-	return complexGlyph(cluster, runes, 1)
-}
-
-// expansionGlyph returns a simple square glyph with the provided cluster
-// value and number of glyphs.
-func expansionGlyph(cluster, glyphs int) shaping.Glyph {
-	return complexGlyph(cluster, 1, glyphs)
-}
-
-// complexGlyph returns a simple square glyph with the provided cluster
-// value, number of associated runes, and number of glyphs in the cluster.
-func complexGlyph(cluster, runes, glyphs int) shaping.Glyph {
-	return shaping.Glyph{
-		Width:        fixed.I(10),
-		Height:       fixed.I(10),
-		XAdvance:     fixed.I(10),
-		YAdvance:     fixed.I(10),
-		YBearing:     fixed.I(10),
-		ClusterIndex: cluster,
-		GlyphCount:   glyphs,
-		RuneCount:    runes,
-	}
-}
-
 // copyLines performs a deep copy of the provided lines. This is necessary if you
 // want to use the line wrapper again while also using the lines.
 func copyLines(lines []shaping.Line) []shaping.Line {


### PR DESCRIPTION
This makes gio ready for the upcoming breaking changes in go-text/typesetting.