### PR TITLE
app: enable transparent CSD windows on Wayland

### DIFF
--- a/app/os_wayland.go
+++ b/app/os_wayland.go
@@ -1121,6 +1121,7 @@ func (w *window) setWindowConstraints() {
 	if scaled := w.config.MaxSize.Div(w.scale); scaled != (image.Point{}) {
 		C.xdg_toplevel_set_max_size(w.topLvl, C.int32_t(scaled.X), C.int32_t(scaled.Y+decoHeight))
 	}
+	w.updateOpaqueRegion()
 }
 
 // decoHeight returns the adjustment for client-side decorations, if applicable.
@@ -1724,6 +1725,12 @@ func (w *window) systemGesture() (*C.struct_wl_cursor, C.uint32_t) {
 }
 
 func (w *window) updateOpaqueRegion() {
+	if !w.config.Decorated {
+		// Don't mark CSD windows as opaque so the compositor can apply
+		// rounded corners and transparency effects.
+		C.wl_surface_set_opaque_region(w.surf, nil)
+		return
+	}
 	reg := C.wl_compositor_create_region(w.disp.compositor)
 	C.wl_region_add(reg, 0, 0, C.int32_t(w.size.X), C.int32_t(w.size.Y))
 	C.wl_surface_set_opaque_region(w.surf, reg)

--- a/app/window.go
+++ b/app/window.go
@@ -207,13 +207,9 @@ func (w *Window) validateAndProcess(size image.Point, sync bool, frame *op.Ops, 
 }
 
 func (w *Window) frame(frame *op.Ops, viewport image.Point) error {
-	if runtime.GOOS == "js" {
-		// Use transparent black when Gio is embedded, to allow mixing of Gio and
-		// foreign content below.
-		w.gpu.Clear(color.NRGBA{A: 0x00, R: 0x00, G: 0x00, B: 0x00})
-	} else {
-		w.gpu.Clear(color.NRGBA{A: 0xff, R: 0xff, G: 0xff, B: 0xff})
-	}
+	// Use transparent clear color to support window transparency and
+	// compositor-drawn rounded corners on Wayland/macOS.
+	w.gpu.Clear(color.NRGBA{A: 0x00, R: 0x00, G: 0x00, B: 0x00})
 	target, err := w.ctx.RenderTarget()
 	if err != nil {
 		return err


### PR DESCRIPTION
This patch enables window transparency and compositor-drawn rounded corners
for undecorated (CSD) windows on Wayland.

Changes:
- Clear framebuffer with transparent black instead of opaque white
- Skip setting opaque region for CSD windows so compositors can apply
  rounded corners and transparency
- Call updateOpaqueRegion in setWindowConstraints to apply after options change

Without this, undecorated Gio windows on GNOME/KDE cannot have transparent
backgrounds or compositor-rounded corners because the surface is always
marked fully opaque.

Tested on GNOME 50 (Wayland). Apps can now use Decorated(false) with a
semi-transparent background and get proper rounded corners from the compositor,
matching the behavior of GTK/Qt CSD apps.