### PR TITLE
app: restore a minimized window on system.ActionRaise

### DIFF
--- a/app/internal/windows/windows.go
+++ b/app/internal/windows/windows.go
@@ -260,6 +260,7 @@ const (
 	SW_SHOWMAXIMIZED = 3
 	SW_SHOWNORMAL    = 1
 	SW_SHOW          = 5
+	SW_RESTORE       = 9
 
 	SWP_FRAMECHANGED  = 0x0020
 	SWP_NOMOVE        = 0x0002
@@ -461,6 +462,7 @@ var (
 	_ReleaseDC                   = user32.NewProc("ReleaseDC")
 	_ScreenToClient              = user32.NewProc("ScreenToClient")
 	_ShowWindow                  = user32.NewProc("ShowWindow")
+	_IsIconic                    = user32.NewProc("IsIconic")
 	_SendMessage                 = user32.NewProc("SendMessageW")
 	_SetCapture                  = user32.NewProc("SetCapture")
 	_SetCursor                   = user32.NewProc("SetCursor")
@@ -962,6 +964,12 @@ func ScreenToClient(hwnd syscall.Handle, p *Point) {
 
 func ShowWindow(hwnd syscall.Handle, nCmdShow int32) {
 	_ShowWindow.Call(uintptr(hwnd), uintptr(nCmdShow))
+}
+
+// IsIconic reports whether the window is minimized.
+func IsIconic(hwnd syscall.Handle) bool {
+	r, _, _ := _IsIconic.Call(uintptr(hwnd))
+	return r != 0
 }
 
 func TranslateMessage(m *Msg) {

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -929,6 +929,13 @@ func (w *window) Perform(acts system.Action) {
 			y := (mi.Bottom - mi.Top - dy) / 2
 			windows.SetWindowPos(w.hwnd, 0, x, y, dx, dy, windows.SWP_NOZORDER|windows.SWP_FRAMECHANGED)
 		case system.ActionRaise:
+			// A minimized window has to be restored before it can be
+			// brought to the front; SetForegroundWindow on its own
+			// leaves it minimized, so raising an iconified window did
+			// nothing at all.
+			if windows.IsIconic(w.hwnd) {
+				windows.ShowWindow(w.hwnd, windows.SW_RESTORE)
+			}
 			windows.SetForegroundWindow(w.hwnd)
 			windows.SetWindowPos(w.hwnd, windows.HWND_TOP, 0, 0, 0, 0,
 				windows.SWP_NOMOVE|windows.SWP_NOSIZE|windows.SWP_SHOWWINDOW)


### PR DESCRIPTION
SetForegroundWindow does not un-minimize, so a minimized window ignored
system.ActionRaise entirely. The common consumers of ActionRaise - tray icon
click, single-instance handoff, notification activation - are exactly the
cases where the window is likely minimized.

window.Perform now restores first: if IsIconic reports the window minimized,
call ShowWindow(SW_RESTORE) before the existing SetForegroundWindow +
SetWindowPos(HWND_TOP) sequence. Non-minimized windows take the exact same
path as before. Adds the IsIconic binding and the SW_RESTORE constant.

This composes with the recent "app: [Windows] don't make raised windows
topmost" change (30dc7ff2) in the same switch arm, and mirrors the
accepted macOS fix for the same pain point (activate the app on raise).

Verified on Windows 10 (LTSC 2021): raising from a tray icon restores and
foregrounds a minimized window; raising a visible window is unchanged.
