### PR TITLE
app: prefer the IDI_APPLICATION icon for the window class

### DIFF
--- a/app/internal/windows/windows.go
+++ b/app/internal/windows/windows.go
@@ -236,6 +236,8 @@ const (
 	IDC_UPARROW     = 32516 // Vertical arrow
 	IDC_WAIT        = 32514 // Hour
 
+	IDI_APPLICATION = 32512 // Default application icon
+
 	INFINITE = 0xFFFFFFFF
 
 	LOGPIXELSX = 88

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -135,7 +135,19 @@ func initResources() error {
 		return err
 	}
 	resources.cursor = c
-	icon, _ := windows.LoadImage(hInst, iconID, windows.IMAGE_ICON, 0, 0, windows.LR_DEFAULTSIZE|windows.LR_SHARED)
+	// Prefer an icon supplied at IDI_APPLICATION, which is where a
+	// resource author puts an icon meant for the window and title bar.
+	// Fall back to the first icon group for resources built without
+	// one, which is the previous behavior. A binary with no icon
+	// resources at all keeps an icon-less window class, as before.
+	var icon syscall.Handle
+	for _, id := range []uint32{windows.IDI_APPLICATION, iconID} {
+		h, err := windows.LoadImage(hInst, id, windows.IMAGE_ICON, 0, 0, windows.LR_DEFAULTSIZE|windows.LR_SHARED)
+		if err == nil {
+			icon = h
+			break
+		}
+	}
 
 	appid, err := syscall.UTF16PtrFromString(ID)
 	if err != nil {


### PR DESCRIPTION
initResources loads the window-class icon from resource ID 1 - the first
icon group, which is also the icon Explorer and the taskbar show for the
executable. An app cannot currently give its window a different icon from
its file icon (a common need: file icons are detailed, title-bar icons want
a simplified glyph).

initResources now tries LoadImage(hInst, IDI_APPLICATION (32512), ...)
first and falls back to resource ID 1 when the executable has no such
resource. Binaries without an IDI_APPLICATION resource group behave exactly
as before.

Design note: this reuses the IDI_APPLICATION identifier as an app-local
resource ID, i.e. a Gio-defined convention for resource authors rather than
a new API. If an explicit option (window icon via app.Option) is preferred,
I am happy to rework it that way - this variant has the advantage of
requiring no API surface and working purely from the resource script.

Verified on Windows 10 (LTSC 2021) with a .rc-embedded 32512 icon group
(window shows the simplified icon, taskbar/Explorer keep the ID-1 icon) and
with binaries lacking the resource (behavior identical to upstream).
