### PR TITLE
widget: allow selection to clear at edge of textbox with arrow key

### DIFF
--- a/widget/editor.go
+++ b/widget/editor.go
@@ -387,10 +387,10 @@ func (e *Editor) processKey(gtx layout.Context) (EditorEvent, bool) {
 		key.Filter{Focus: e, Name: key.NameEnd, Optional: key.ModShortcut | key.ModShift},
 		key.Filter{Focus: e, Name: key.NamePageDown, Optional: key.ModShift},
 		key.Filter{Focus: e, Name: key.NamePageUp, Optional: key.ModShift},
-		condFilter(!atBeginning, key.Filter{Focus: e, Name: key.NameLeftArrow, Optional: key.ModShortcutAlt | key.ModShift}),
-		condFilter(!atBeginning, key.Filter{Focus: e, Name: key.NameUpArrow, Optional: key.ModShortcutAlt | key.ModShift}),
-		condFilter(!atEnd, key.Filter{Focus: e, Name: key.NameRightArrow, Optional: key.ModShortcutAlt | key.ModShift}),
-		condFilter(!atEnd, key.Filter{Focus: e, Name: key.NameDownArrow, Optional: key.ModShortcutAlt | key.ModShift}),
+		key.Filter{Focus: e, Name: key.NameLeftArrow, Optional: key.ModShortcutAlt | key.ModShift | key.ModCtrl},
+		key.Filter{Focus: e, Name: key.NameUpArrow, Optional: key.ModShortcutAlt | key.ModShift | key.ModCtrl},
+		key.Filter{Focus: e, Name: key.NameRightArrow, Optional: key.ModShortcutAlt | key.ModShift | key.ModCtrl},
+		key.Filter{Focus: e, Name: key.NameDownArrow, Optional: key.ModShortcutAlt | key.ModShift | key.ModCtrl},
 	}
 	// adjust keeps track of runes dropped because of MaxLen.
 	var adjust int


### PR DESCRIPTION
This pull request fixes editor behaviour to allow selection to be cleared when either:
a) The selection extends to the first character in the editor, and the user presses the left/up arrow keys.
b) The selection extends to the last character in the editor, and the user presses the right/down arrow keys.

Added ModCtrl to the filters as it should also take effect on any key modifier.

The previous behaviour without this patch is that when the selection extends to the start/end, the user cannot clear the selection when pressing an arrow key in the direction of the start/end.