### PR TITLE
widget: make editor support control+arrow word navigation

### DIFF
--- a/widget/editor.go
+++ b/widget/editor.go
@@ -499,6 +499,20 @@ func (e *Editor) command(gtx layout.Context, k key.Event) (EditorEvent, bool) {
 	if k.Modifiers.Contain(key.ModShift) {
 		selAct = selectionExtend
 	}
+	if k.Modifiers.Contain(key.ModCtrl) {
+		switch k.Name {
+		case key.NameLeftArrow:
+			if selAct == selectionClear {
+				e.text.ClearSelection()
+			}
+			e.text.MoveWord(-1*direction, selAct)
+		case key.NameRightArrow:
+			if selAct == selectionClear {
+				e.text.ClearSelection()
+			}
+			e.text.MoveWord(1*direction, selAct)
+		}
+	}
 	if k.Modifiers.Contain(key.ModShortcut) {
 		switch k.Name {
 		// Initiate a paste operation, by requesting the clipboard contents; other


### PR DESCRIPTION
This pull requests implements navigation by word (control) behaviour that works with and without pressing Shift (for selection).