### PR TITLE
app: [Windows] fix custom decoration after restore

### DIFF
--- a/app/internal/windows/windows.go
+++ b/app/internal/windows/windows.go
@@ -244,6 +244,7 @@ const (
 
 	MDT_EFFECTIVE_DPI = 0
 
+	MONITOR_DEFAULTTONULL    = 0
 	MONITOR_DEFAULTTOPRIMARY = 1
 
 	NI_COMPOSITIONSTR = 0x0015
@@ -451,7 +452,7 @@ var (
 	_LoadCursor                  = user32.NewProc("LoadCursorW")
 	_LoadImage                   = user32.NewProc("LoadImageW")
 	_MonitorFromPoint            = user32.NewProc("MonitorFromPoint")
-	_MonitorFromWindow           = user32.NewProc("MonitorFromWindow")
+	_MonitorFromRect             = user32.NewProc("MonitorFromRect")
 	_MoveWindow                  = user32.NewProc("MoveWindow")
 	_MsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
 	_OpenClipboard               = user32.NewProc("OpenClipboard")
@@ -710,12 +711,15 @@ func GetWindowPlacement(hwnd syscall.Handle) WindowPlacement {
 	return wp
 }
 
-func GetMonitorInfo(hwnd syscall.Handle) MonitorInfo {
+func GetMonitorInfo(r Rect, flags uint32) (MonitorInfo, bool) {
+	monitor, _, _ := _MonitorFromRect.Call(uintptr(unsafe.Pointer(&r)), uintptr(flags))
+	if monitor == 0 {
+		return MonitorInfo{}, false
+	}
 	var mi MonitorInfo
 	mi.cbSize = uint32(unsafe.Sizeof(mi))
-	v, _, _ := _MonitorFromWindow.Call(uintptr(hwnd), MONITOR_DEFAULTTOPRIMARY)
-	_GetMonitorInfo.Call(v, uintptr(unsafe.Pointer(&mi)))
-	return mi
+	_GetMonitorInfo.Call(monitor, uintptr(unsafe.Pointer(&mi)))
+	return mi, true
 }
 
 func GetWindowLong(hwnd syscall.Handle, index uintptr) (val uintptr) {

--- a/app/os_windows.go
+++ b/app/os_windows.go
@@ -373,7 +373,10 @@ func windowProc(hwnd syscall.Handle, msg uint32, wParam, lParam uintptr) uintptr
 		// state. See https://devblogs.microsoft.com/oldnewthing/20150304-00/?p=44543.
 		// Note that trying to do the adjustment in WM_GETMINMAXINFO is ignored by Windows.
 		szp := (*windows.NCCalcSizeParams)(unsafe.Pointer(lParam))
-		mi := windows.GetMonitorInfo(w.hwnd)
+		mi, ok := windows.GetMonitorInfo(szp.Rgrc[0], windows.MONITOR_DEFAULTTONULL)
+		if !ok {
+			return 0
+		}
 		szp.Rgrc[0] = mi.WorkArea
 		return 0
 	case windows.WM_PAINT:
@@ -1021,7 +1024,11 @@ func (w *window) Perform(acts system.Action) {
 			dx := r.Right - r.Left
 			dy := r.Bottom - r.Top
 			// Center in the usable area of the current monitor.
-			area := windows.GetMonitorInfo(w.hwnd).WorkArea
+			mi, ok := windows.GetMonitorInfo(r, windows.MONITOR_DEFAULTTONULL)
+			if !ok {
+				break
+			}
+			area := mi.WorkArea
 			x := (area.Right + area.Left - dx) / 2
 			y := (area.Bottom + area.Top - dy) / 2
 			windows.SetWindowPos(w.hwnd, 0, x, y, dx, dy, windows.SWP_NOZORDER|windows.SWP_FRAMECHANGED)

--- a/app/window.go
+++ b/app/window.go
@@ -669,6 +669,9 @@ func (w *Window) processEvent(e event.Event) bool {
 		e2.Config = w.effectiveConfig()
 		w.coalesced.cfg = &e2
 		if f := w.decorations.Config.Focused; f != wasFocused {
+			if !f {
+				w.queue.Queue(pointer.Event{Kind: pointer.Cancel})
+			}
 			w.queue.Queue(key.FocusEvent{Focus: f})
 		}
 		t, handled := w.queue.WakeupTime()


### PR DESCRIPTION
On Windows with extended displays, restoring a minimized undecorated
window can leave hover state and hit testing in the wrong state.

Clear the pointer state and refresh the non-client area when restoring.


Fixes: https://todo.sr.ht/~eliasnaur/gio/702
Fixes: https://todo.sr.ht/~eliasnaur/gio/703