### PR TITLE
op/clip: add reusable path cache

### DIFF
--- a/op/clip/clip.go
+++ b/op/clip/clip.go
@@ -116,6 +116,20 @@ type PathSpec struct {
 	hash        uint64
 }
 
+// PathCache stores path data for reuse across frames.
+// Call Begin again when the path geometry changes.
+type PathCache struct {
+	ops op.Ops
+}
+
+// Begin starts a new path and invalidates any previously returned PathSpec.
+func (c *PathCache) Begin() Path {
+	c.ops.Reset()
+	var p Path
+	p.Begin(&c.ops)
+	return p
+}
+
 // Path constructs a Op clip path described by lines and
 // Bézier curves, where drawing outside the Path is discarded.
 // The inside-ness of a pixel is determines by the non-zero winding rule,

--- a/op/clip/clip_test.go
+++ b/op/clip/clip_test.go
@@ -50,6 +50,72 @@ func TestPathBegin(t *testing.T) {
 	_ = w.Frame(ops)
 }
 
+func TestPathCache(t *testing.T) {
+	var cache clip.PathCache
+	p := cache.Begin()
+	p.MoveTo(f32.Pt(10, 10))
+	p.LineTo(f32.Pt(90, 10))
+	p.LineTo(f32.Pt(50, 90))
+	p.Close()
+	path := p.End()
+
+	w := newWindow(t, 100, 100)
+	if w == nil {
+		return
+	}
+	defer w.Release()
+	var ops op.Ops
+	for range 2 {
+		stack := clip.Outline{Path: path}.Op().Push(&ops)
+		paint.Fill(&ops, color.NRGBA{A: 0xff})
+		stack.Pop()
+		if err := w.Frame(&ops); err != nil {
+			t.Fatal(err)
+		}
+		ops.Reset()
+	}
+}
+
+func BenchmarkPathCache(b *testing.B) {
+	build := func(p *clip.Path) {
+		p.MoveTo(f32.Pt(0, 0))
+		for i := range 64 {
+			x := float32(i*8 + 4)
+			p.CubeTo(f32.Pt(x, 0), f32.Pt(x, 64), f32.Pt(x+4, 32))
+		}
+		p.Close()
+	}
+	for _, cached := range []bool{true, false} {
+		name := "Rebuild"
+		if cached {
+			name = "Cached"
+		}
+		b.Run(name, func(b *testing.B) {
+			var ops op.Ops
+			var path clip.PathSpec
+			var cache clip.PathCache
+			if cached {
+				p := cache.Begin()
+				build(&p)
+				path = p.End()
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if !cached {
+					var p clip.Path
+					p.Begin(&ops)
+					build(&p)
+					path = p.End()
+				}
+				stack := clip.Outline{Path: path}.Op().Push(&ops)
+				paint.PaintOp{}.Add(&ops)
+				stack.Pop()
+				ops.Reset()
+			}
+		})
+	}
+}
+
 func TestTransformChecks(t *testing.T) {
 	defer func() {
 		if err := recover(); err == nil {


### PR DESCRIPTION
Path data is normally stored in the frame Ops and becomes invalid after
Ops.Reset. This means unchanged paths have to be rebuilt every frame.

Add PathCache to keep path data in a separate Ops list so static paths can
be reused across frames.

